### PR TITLE
Clarify MSVC 2015 is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Add [multirust-rs](https://crates.io/crates/multirust-rs) or [rust-install](http
 ### Installing from binaries
 
 - [Windows GNU 64-bit installer](https://github.com/Diggsey/multirust-rs-binaries/raw/master/x86_64-pc-windows-gnu/multirust-rs.exe)
-- [Windows MSVC 64-bit installer](https://github.com/Diggsey/multirust-rs-binaries/raw/master/x86_64-pc-windows-msvc/multirust-rs.exe)
+- [Windows MSVC 64-bit installer](https://github.com/Diggsey/multirust-rs-binaries/raw/master/x86_64-pc-windows-msvc/multirust-rs.exe)<sup>[\*1](#vs2015)</sup>
 - [Windows GNU 32-bit installer](https://github.com/Diggsey/multirust-rs-binaries/raw/master/i686-pc-windows-gnu/multirust-rs.exe)
-- [Windows MSVC 32-bit installer](https://github.com/Diggsey/multirust-rs-binaries/raw/master/i686-pc-windows-msvc/multirust-rs.exe)
+- [Windows MSVC 32-bit installer](https://github.com/Diggsey/multirust-rs-binaries/raw/master/i686-pc-windows-msvc/multirust-rs.exe)<sup>[\*1](#vs2015)</sup>
 - [Linux 64-bit installer](https://github.com/Diggsey/multirust-rs-binaries/raw/master/x86_64-unknown-linux-gnu/multirust-rs)
 - [Linux 32-bit installer](https://github.com/Diggsey/multirust-rs-binaries/raw/master/i686-unknown-linux-gnu/multirust-rs)
 - [Mac 64-bit installer](https://github.com/Diggsey/multirust-rs-binaries/raw/master/x86_64-apple-darwin/multirust-rs)
@@ -30,6 +30,7 @@ Add [multirust-rs](https://crates.io/crates/multirust-rs) or [rust-install](http
 
 Binaries for other platforms are not yet available. Follow the instructions below for installing from source.
 
+<a name="vs2015">\*1)</a> MSVC builds of `multirust-rs` additionally require an [installation of Visual Studio 2015](https://www.visualstudio.com/downloads). Make sure to check the "C++ tools" option. No additional software installation is necessary for basic use of the GNU build.
 
 ### Installing from source
 


### PR DESCRIPTION
I just confirmed `multirust-rs.exe` required `VCRUNTIME140.dll` but not sure what was required for MSVC `rustc.exe`.  Please adjust the wording accordingly.