### PR TITLE
Don't consider HOME when searching for user home dir on windows

### DIFF
--- a/src/multirust-cli/main.rs
+++ b/src/multirust-cli/main.rs
@@ -85,7 +85,11 @@ fn run_multirust() -> Result<()> {
             // ~/.multirust/tmp/multirust-$random, and execute it with
             // `self install` as the arguments.  FIXME: Verify this
             // works.
-            self_update::install(true, false)
+            if cfg!(windows) {
+                self_update::install(false, false)
+            } else {
+                self_update::install(true, false)
+            }
         }
         Some(_) => {
             proxy_mode::main()

--- a/src/multirust-utils/Cargo.toml
+++ b/src/multirust-utils/Cargo.toml
@@ -15,27 +15,36 @@ license = "MIT OR Apache-2.0"
 openssl = "0.7.2"
 hyper = "0.7.0"
 rand = "0.3.11"
+scopeguard = "0.1.2"
 
 [target.x86_64-pc-windows-gnu.dependencies]
 winapi = "0.2.4"
 winreg = "0.3.2"
 shell32-sys = "0.1.1"
 ole32-sys = "0.2.0"
+kernel32-sys = "0.2.1"
+advapi32-sys = "0.2.0"
 
 [target.x86_64-pc-windows-msvc.dependencies]
 winapi = "0.2.4"
 winreg = "0.3.2"
 shell32-sys = "0.1.1"
 ole32-sys = "0.2.0"
+kernel32-sys = "0.2.1"
+advapi32-sys = "0.2.0"
 
 [target.i686-pc-windows-gnu.dependencies]
 winapi = "0.2.4"
 winreg = "0.3.2"
 shell32-sys = "0.1.1"
 ole32-sys = "0.2.0"
+kernel32-sys = "0.2.1"
+advapi32-sys = "0.2.0"
 
 [target.i686-pc-windows-msvc.dependencies]
 winapi = "0.2.4"
 winreg = "0.3.2"
 shell32-sys = "0.1.1"
 ole32-sys = "0.2.0"
+kernel32-sys = "0.2.1"
+advapi32-sys = "0.2.0"

--- a/src/multirust-utils/src/errors.rs
+++ b/src/multirust-utils/src/errors.rs
@@ -123,6 +123,8 @@ pub enum Error {
         path: PathBuf,
         error: io::Error,
     },
+    CargoHome,
+    MultirustHome,
 }
 
 pub type Result<T> = ::std::result::Result<T, Error>;
@@ -192,6 +194,8 @@ impl error::Error for Error {
             OpeningBrowser { error: Some(_) } => "could not open browser",
             OpeningBrowser { error: None } => "could not open browser: no browser installed",
             SettingPermissions {..} => "failed to set permissions",
+            CargoHome => "couldn't find value of CARGO_HOME",
+            MultirustHome => "couldn't find value of MULTIRUST_HOME",
         }
     }
 
@@ -226,6 +230,8 @@ impl error::Error for Error {
             // Variant carrying `error: Option<io::Error>`.
             OpeningBrowser { error: Some(ref e) } => Some(e),
             OpeningBrowser { error: None } => None,
+            CargoHome |
+            MultirustHome => None,
         }
     }
 }
@@ -357,7 +363,9 @@ impl Display for Error {
                        "failed to set permissions for: '{} ({})'",
                        path.display(),
                        error)
-            }
+            },
+            CargoHome => write!(f, "couldn't find value of CARGO_HOME"),
+            MultirustHome => write!(f, "couldn't find value of MULTIRUST_HOME"),
         }
     }
 }

--- a/src/multirust-utils/src/lib.rs
+++ b/src/multirust-utils/src/lib.rs
@@ -4,6 +4,8 @@
 extern crate hyper;
 extern crate openssl;
 extern crate rand;
+#[macro_use]
+extern crate scopeguard;
 
 #[cfg(windows)]
 extern crate winapi;
@@ -13,6 +15,10 @@ extern crate winreg;
 extern crate shell32;
 #[cfg(windows)]
 extern crate ole32;
+#[cfg(windows)]
+extern crate kernel32;
+#[cfg(windows)]
+extern crate advapi32;
 
 pub mod notify;
 pub mod errors;

--- a/src/multirust/config.rs
+++ b/src/multirust/config.rs
@@ -51,7 +51,7 @@ pub struct Cfg {
 impl Cfg {
     pub fn from_env(notify_handler: SharedNotifyHandler) -> Result<Self> {
         // Set up the multirust home directory
-        let multirust_dir = try!(multirust_dir());
+        let multirust_dir = try!(utils::multirust_home());
 
         try!(utils::ensure_dir_exists("home", &multirust_dir, ntfy!(&notify_handler)));
 
@@ -325,13 +325,3 @@ impl Cfg {
     }
 }
 
-// NB: multirust and cargo use the same scheme for determining
-// their home directory
-pub fn multirust_dir() -> Result<PathBuf> {
-    let cwd = try!(env::current_dir().map_err(|_| Error::MultirustHome));
-    let multirust_home = env::var_os("MULTIRUST_HOME").map(|home| {
-        cwd.join(home)
-    });
-    let user_home = env::home_dir().map(|p| p.join(".multirust"));
-    multirust_home.or(user_home).ok_or(Error::MultirustHome)
-}

--- a/src/multirust/errors.rs
+++ b/src/multirust/errors.rs
@@ -56,8 +56,6 @@ pub enum Error {
     AddingRequiredComponent(String, Component),
     RemovingRequiredComponent(String, Component),
     NoExeName,
-    CargoHome,
-    MultirustHome,
     NotSelfInstalled(PathBuf),
     CantSpawnWindowsGcExe,
     WindowsUninstallMadness(io::Error),
@@ -181,8 +179,6 @@ impl error::Error for Error {
             AddingRequiredComponent(_, _) => "required component cannot be added",
             RemovingRequiredComponent(_, _) => "required component cannot be removed",
             NoExeName => "couldn't determine self executable name",
-            CargoHome => "couldn't find value of CARGO_HOME",
-            MultirustHome => "couldn't find value of MULTIRUST_HOME",
             NotSelfInstalled(_) => "multirust is not installed",
             CantSpawnWindowsGcExe => "failed to spawn cleanup process",
             WindowsUninstallMadness(_) => "failure during windows uninstall",
@@ -214,8 +210,6 @@ impl error::Error for Error {
             AddingRequiredComponent(_, _) |
             RemovingRequiredComponent(_, _) |
             NoExeName |
-            CargoHome |
-            MultirustHome |
             NotSelfInstalled(_) |
             CantSpawnWindowsGcExe |
             SelfUpdateFailed |
@@ -265,8 +259,6 @@ impl Display for Error {
                        c.pkg, c.target, t)
             }
             NoExeName => write!(f, "couldn't determine self executable name"),
-            CargoHome => write!(f, "{}", self.description()),
-            MultirustHome => write!(f, "{}", self.description()),
             NotSelfInstalled(ref p) => {
                 write!(f, "multirust is not installed at '{}'", p.display())
             }

--- a/src/multirust/toolchain.rs
+++ b/src/multirust/toolchain.rs
@@ -216,6 +216,14 @@ impl<'a> Toolchain<'a> {
 
         self.set_ldpath(cmd);
 
+        // Because multirust and cargo use slightly different
+        // definitions of cargo home (multirust doesn't read HOME on
+        // windows), we must set it here to ensure cargo and
+        // multirust agree.
+        if let Ok(cargo_home) = utils::cargo_home() {
+            env_var::set_path("CARGO_HOME", &cargo_home, cmd);
+        }
+
         env_var::set_path("PATH", bin_path, cmd);
         env_var::inc("RUST_RECURSION_COUNT", cmd);
 

--- a/tests/cli-self-update.rs
+++ b/tests/cli-self-update.rs
@@ -887,6 +887,7 @@ fn install_deletes_legacy_multirust_bins() {
 // install to go to the wrong place. Detect this scenario specifically
 // and avoid it.
 #[test]
+#[cfg(unix)] // Can't test on windows without clobbering the home dir
 fn legacy_upgrade_installs_to_correct_location() {
     setup(&|config, _, home| {
         let fake_cargo = config.homedir.path().join(".multirust/cargo");


### PR DESCRIPTION
HOME is only set under msys, and it's set to something wrong.

Also fixes the bin path that is deleted during upgrade,
from FOLDERID_Profile to FOLDERID_LocalAppData.