### PR TITLE
Emit proper errors for `multirust update $bogus`. Fixes #111

### DIFF
--- a/src/multirust-cli/multirust_mode.rs
+++ b/src/multirust-cli/multirust_mode.rs
@@ -115,8 +115,11 @@ fn default_(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
     if !try!(common_install_args(&toolchain, m)) {
         if !toolchain.is_custom() {
             try!(toolchain.install_from_dist_if_not_installed());
+        } else if !toolchain.exists() {
+            return Err(Error::ToolchainNotInstalled(toolchain.name().to_string()));
         }
     }
+
 
     try!(toolchain.make_default());
 
@@ -129,7 +132,11 @@ fn update(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
     if let Some(name) = m.value_of("toolchain") {
         let toolchain = try!(cfg.get_toolchain(name, true));
         if !try!(common_install_args(&toolchain, m)) {
-            try!(toolchain.install_from_dist())
+            if !toolchain.is_custom() {
+                try!(toolchain.install_from_dist())
+            } else if !toolchain.exists() {
+                return Err(Error::ToolchainNotInstalled(toolchain.name().to_string()));
+            }
         }
         println!("");
         try!(show_channel_version(cfg, name));

--- a/src/multirust-dist/src/errors.rs
+++ b/src/multirust-dist/src/errors.rs
@@ -38,6 +38,7 @@ pub enum Error {
     InvalidFileExtension,
     InvalidInstaller,
     InvalidToolchainName(String),
+    InvalidCustomToolchainName(String),
     NotInstalledHere,
     UnsupportedHost(String),
     ChecksumFailed {
@@ -152,7 +153,8 @@ impl error::Error for Error {
             Temp(ref e) => error::Error::description(e),
             InvalidFileExtension => "invalid file extension",
             InvalidInstaller => "invalid installer",
-            InvalidToolchainName(_) => "invalid custom toolchain name",
+            InvalidToolchainName(_) => "invalid toolchain name",
+            InvalidCustomToolchainName(_) => "invalid custom toolchain name",
             NotInstalledHere => "not installed here",
             UnsupportedHost(_) => "binary package not provided for host",
             ChecksumFailed {..} => "checksum failed",
@@ -196,6 +198,7 @@ impl error::Error for Error {
             InvalidFileExtension |
             InvalidInstaller |
             InvalidToolchainName(_) |
+            InvalidCustomToolchainName(_) |
             NotInstalledHere |
             UnsupportedHost(_) |
             ChecksumFailed {..} |
@@ -231,7 +234,8 @@ impl Display for Error {
 
             InvalidFileExtension => write!(f, "invalid file extension"),
             InvalidInstaller => write!(f, "invalid installer"),
-            InvalidToolchainName(ref s) => write!(f, "invalid custom toolchain name: '{}'", s),
+            InvalidToolchainName(ref s) => write!(f, "invalid toolchain name: '{}'", s),
+            InvalidCustomToolchainName(ref s) => write!(f, "invalid custom toolchain name: '{}'", s),
             NotInstalledHere => write!(f, "not installed here"),
             UnsupportedHost(ref spec) => {
                 write!(f, "a binary package was not provided for: '{}'", spec)

--- a/src/multirust/toolchain.rs
+++ b/src/multirust/toolchain.rs
@@ -137,7 +137,7 @@ impl<'a> Toolchain<'a> {
 
     fn ensure_custom(&self) -> Result<()> {
         if !self.is_custom() {
-            Err(Error::Install(::multirust_dist::Error::InvalidToolchainName(self.name.to_string())))
+            Err(Error::Install(::multirust_dist::Error::InvalidCustomToolchainName(self.name.to_string())))
         } else {
             Ok(())
         }
@@ -276,7 +276,8 @@ impl<'a> Toolchain<'a> {
         // FIXME: This toolchain handling is a mess. Just do it once
         // when the toolchain is created.
         let ref toolchain = self.name;
-        let ref toolchain = try!(ToolchainDesc::from_str(toolchain));
+        let ref toolchain = try!(ToolchainDesc::from_str(toolchain)
+                                 .map_err(|_| Error::ComponentsUnsupported(self.name.to_string())));
         let trip = toolchain.target_triple();
         let prefix = InstallPrefix::from(self.path.to_owned());
         let manifestation = try!(Manifestation::open(prefix, &trip));
@@ -307,7 +308,8 @@ impl<'a> Toolchain<'a> {
         }
 
         let ref toolchain = self.name;
-        let ref toolchain = try!(ToolchainDesc::from_str(toolchain));
+        let ref toolchain = try!(ToolchainDesc::from_str(toolchain)
+                                 .map_err(|_| Error::ComponentsUnsupported(self.name.to_string())));
         let trip = toolchain.target_triple();
         let prefix = InstallPrefix::from(self.path.to_owned());
         let manifestation = try!(Manifestation::open(prefix, &trip));
@@ -350,7 +352,8 @@ impl<'a> Toolchain<'a> {
         }
 
         let ref toolchain = self.name;
-        let ref toolchain = try!(ToolchainDesc::from_str(toolchain));
+        let ref toolchain = try!(ToolchainDesc::from_str(toolchain)
+                                 .map_err(|_| Error::ComponentsUnsupported(self.name.to_string())));
         let trip = toolchain.target_triple();
         let prefix = InstallPrefix::from(self.path.to_owned());
         let manifestation = try!(Manifestation::open(prefix, &trip));

--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -151,3 +151,25 @@ r"info: deleted directory '{}'
 ", config.homedir.path().display()));
     });
 }
+
+// Issue #111
+// multirust update nightly-2016-03-1
+#[test]
+fn update_invalid_toolchain() {
+   setup(&|config| {
+        expect_err_ex(config, &["multirust", "update", "nightly-2016-03-1"],
+r"",
+r"error: toolchain 'nightly-2016-03-1' is not installed
+");
+   });
+ }
+
+#[test]
+fn default_invalid_toolchain() {
+   setup(&|config| {
+        expect_err_ex(config, &["multirust", "default", "nightly-2016-03-1"],
+r"",
+r"error: toolchain 'nightly-2016-03-1' is not installed
+");
+   });
+}

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -529,7 +529,7 @@ fn list_targets_custom_toolchain() {
         expect_ok(config, &["multirust", "update", "default-from-path",
                             "--copy-local", &path]);
         expect_err(config, &["multirust", "list-targets", "default-from-path"],
-                   "invalid custom toolchain name: 'default-from-path'");
+                   "toolchain 'default-from-path' does not support components");
     });
 }
 
@@ -588,7 +588,7 @@ fn add_target_custom_toolchain() {
         expect_ok(config, &["multirust", "update", "default-from-path",
                             "--copy-local", &path]);
         expect_err(config, &["multirust", "add-target", "default-from-path", clitools::CROSS_ARCH1],
-                   "invalid custom toolchain name: 'default-from-path'");
+                   "toolchain 'default-from-path' does not support components");
     });
 }
 
@@ -672,7 +672,7 @@ fn remove_target_custom_toolchain() {
         expect_ok(config, &["multirust", "update", "default-from-path",
                             "--copy-local", &path]);
         expect_err(config, &["multirust", "remove-target", "default-from-path", clitools::CROSS_ARCH1],
-                   "invalid custom toolchain name: 'default-from-path'");
+                   "toolchain 'default-from-path' does not support components");
     });
 }
 


### PR DESCRIPTION
Make a number of related errors more consistent.