### PR TITLE
Prettify list-targets

### DIFF
--- a/src/multirust-cli/multirust_mode.rs
+++ b/src/multirust-cli/multirust_mode.rs
@@ -340,8 +340,14 @@ fn list_targets(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
     let toolchain = m.value_of("toolchain").unwrap();
     let toolchain = try!(cfg.get_toolchain(toolchain, false));
     for component in try!(toolchain.list_components()) {
-        if component.pkg == "rust-std" {
-            println!("{}", component.target);
+        if component.component.pkg == "rust-std" {
+            if component.required {
+                println!("{} (default)", component.component.target);
+            } else if component.installed {
+                println!("{} (installed)", component.component.target);
+            } else {
+                println!("{}", component.component.target);
+            }
         }
     }
 

--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -6,7 +6,8 @@ extern crate multirust_mock;
 
 use multirust_mock::clitools::{self, Config, Scenario,
                                expect_ok, expect_ok_ex,
-                               expect_err_ex};
+                               expect_err_ex,
+                               this_host_triple};
 use std::env;
 
 fn setup(f: &Fn(&Config)) {
@@ -172,4 +173,24 @@ r"",
 r"error: toolchain 'nightly-2016-03-1' is not installed
 ");
    });
+}
+
+#[test]
+fn list_targets() {
+    setup(&|config| {
+        let trip = this_host_triple();
+        let mut sorted = vec![format!("{} (default)", &*trip),
+                              format!("{} (installed)", clitools::CROSS_ARCH1),
+                              clitools::CROSS_ARCH2.to_string()];
+        sorted.sort();
+
+        let expected = format!("{}\n{}\n{}\n", sorted[0], sorted[1], sorted[2]);
+
+        expect_ok(config, &["multirust", "update", "nightly"]);
+        expect_ok(config, &["multirust", "add-target", "nightly",
+                            clitools::CROSS_ARCH1]);
+        expect_ok_ex(config, &["multirust", "list-targets", "nightly"],
+&expected,
+r"");
+    });
 }


### PR DESCRIPTION
Now the target for the host arch will display "(default)" and
other installed targets "(installed)".

r? @Diggsey 