### PR TITLE
Put process in a job on windows to kill children

### DIFF
--- a/src/multirust-cli/job.rs
+++ b/src/multirust-cli/job.rs
@@ -1,0 +1,83 @@
+// FIXME: stolen from cargo. Should be extracted into a common crate.
+
+//! Job management (mostly for windows)
+//!
+//! Most of the time when you're running cargo you expect Ctrl-C to actually
+//! terminate the entire tree of processes in play, not just the one at the top
+//! (cago). This currently works "by default" on Unix platforms because Ctrl-C
+//! actually sends a signal to the *process group* rather than the parent
+//! process, so everything will get torn down. On Windows, however, this does
+//! not happen and Ctrl-C just kills cargo.
+//!
+//! To achieve the same semantics on Windows we use Job Objects to ensure that
+//! all processes die at the same time. Job objects have a mode of operation
+//! where when all handles to the object are closed it causes all child
+//! processes associated with the object to be terminated immediately.
+//! Conveniently whenever a process in the job object spawns a new process the
+//! child will be associated with the job object as well. This means if we add
+//! ourselves to the job object we create then everything will get torn down!
+
+pub fn setup() {
+    unsafe { imp::setup() }
+}
+
+#[cfg(unix)]
+mod imp {
+    pub unsafe fn setup() {
+    }
+}
+
+#[cfg(windows)]
+mod imp {
+    extern crate kernel32;
+    extern crate winapi;
+
+    use std::mem;
+
+    pub unsafe fn setup() {
+        // Creates a new job object for us to use and then adds ourselves to it.
+        // Note that all errors are basically ignored in this function,
+        // intentionally. Job objects are "relatively new" in Windows,
+        // particularly the ability to support nested job objects. Older
+        // Windows installs don't support this ability. We probably don't want
+        // to force Cargo to abort in this situation or force others to *not*
+        // use job objects, so we instead just ignore errors and assume that
+        // we're otherwise part of someone else's job object in this case.
+
+        let job = kernel32::CreateJobObjectW(0 as *mut _, 0 as *const _);
+        if job.is_null() {
+            return
+        }
+
+        // Indicate that when all handles to the job object are gone that all
+        // process in the object should be killed. Note that this includes our
+        // entire process tree by default because we've added ourselves and and
+        // our children will reside in the job once we spawn a process.
+        let mut info: winapi::JOBOBJECT_EXTENDED_LIMIT_INFORMATION;
+        info = mem::zeroed();
+        info.BasicLimitInformation.LimitFlags =
+            winapi::JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let r = kernel32::SetInformationJobObject(job,
+                        winapi::JobObjectExtendedLimitInformation,
+                        &mut info as *mut _ as winapi::LPVOID,
+                        mem::size_of_val(&info) as winapi::DWORD);
+        if r == 0 {
+            kernel32::CloseHandle(job);
+            return
+        }
+
+        // Assign our process to this job object, meaning that our children will
+        // now live or die based on our existence.
+        let me = kernel32::GetCurrentProcess();
+        let r = kernel32::AssignProcessToJobObject(job, me);
+        if r == 0 {
+            kernel32::CloseHandle(job);
+            return
+        }
+
+        // Intentionally leak the `job` handle here. We've got the only
+        // reference to this job, so once it's gone we and all our children will
+        // be killed. This typically won't happen unless Cargo itself is
+        // ctrl-c'd.
+    }
+}

--- a/src/multirust-cli/main.rs
+++ b/src/multirust-cli/main.rs
@@ -37,6 +37,7 @@ mod proxy_mode;
 mod setup_mode;
 mod self_update;
 mod tty;
+mod job;
 
 use std::env;
 use std::path::PathBuf;

--- a/src/multirust-cli/proxy_mode.rs
+++ b/src/multirust-cli/proxy_mode.rs
@@ -3,9 +3,12 @@ use multirust::{Cfg, Result, Error};
 use multirust_utils::utils;
 use std::env;
 use std::path::PathBuf;
+use job;
 
 pub fn main() -> Result<()> {
     try!(::self_update::cleanup_self_updater());
+
+    job::setup();
 
     let arg0 = env::args().next().map(|a| PathBuf::from(a));
     let arg0 = arg0.as_ref()


### PR DESCRIPTION
It is so annoying to not have this.

cc @alexcrichton This should be in its own crate, but doesn't on its own seem worth the effort. I'm anticipating a few weeks of further refactoring next quarter.

I also didn't write tests, because bleh and you've already got this code tested in cargo. Please don't make me write tests.