### PR TITLE
Fix setting of CARGO_HOME

### DIFF
--- a/src/multirust/toolchain.rs
+++ b/src/multirust/toolchain.rs
@@ -221,7 +221,7 @@ impl<'a> Toolchain<'a> {
         // windows), we must set it here to ensure cargo and
         // multirust agree.
         if let Ok(cargo_home) = utils::cargo_home() {
-            env_var::set_path("CARGO_HOME", &cargo_home, cmd);
+            cmd.env("CARGO_HOME", &cargo_home);
         }
 
         env_var::set_path("PATH", bin_path, cmd);


### PR DESCRIPTION
The env_var::set_path method is for inserting a value into PATH,
so the value of CARGO_HOME ends up being crazy if CARGO_HOME is
already set.