### PR TITLE
Tell cargo where rustc is when printing the version info

### DIFF
--- a/src/multirust-cli/common.rs
+++ b/src/multirust-cli/common.rs
@@ -131,6 +131,11 @@ pub fn show_tool_versions(toolchain: &Toolchain) -> Result<()> {
         if utils::is_file(&cargo_path) {
             let mut cmd = Command::new(&cargo_path);
             cmd.arg("--version");
+            // cargo invokes rustc during --version, this
+            // makes sure it can find it since it may not
+            // be on the `PATH` and multirust does not
+            // manipulate `PATH`.
+            cmd.env("RUSTC", rustc_path);
             toolchain.set_ldpath(&mut cmd);
 
             if utils::cmd_status("cargo", &mut cmd).is_err() {


### PR DESCRIPTION
Cargo runs rustc during --version, and rustc may not necessarily be on
the `PATH`. during proxy operation multirust does not manipulate the
`PATH` variable itself but expects it to be set correctly externally.

Fixes #131, which is fallout from me removing the setting of `PATH` from multirust-rs as well the recent updater changes.

This is hard to test automatically because it relies on behavior of the real cargo that doesn't exist in the mocks.

r? @Diggsey cc @Luthaf