### PR TITLE
Whitespace fixes

### DIFF
--- a/src/multirust-cli/multirust_mode.rs
+++ b/src/multirust-cli/multirust_mode.rs
@@ -257,6 +257,7 @@ fn show_default(cfg: &Cfg) -> Result<()> {
         println!("default toolchain: {}", toolchain.name());
         println!("default location: {}", toolchain.path().display());
 
+        println!("");
         try!(show_tool_versions(&toolchain));
         println!("");
     } else {
@@ -275,6 +276,7 @@ fn show_override(cfg: &Cfg) -> Result<()> {
         // windows path, which is pretty ugly
         println!("override reason: {}", reason);
 
+        println!("");
         try!(show_tool_versions(&toolchain));
         println!("");
     } else {
@@ -349,6 +351,7 @@ fn update_all_channels(cfg: &Cfg) -> Result<()> {
         let _ = write!(t, "{}", name);
         let _ = t.reset();
         let _ = writeln!(t, " revision:");
+        println!("");
         try!(show_tool_versions(&try!(cfg.get_toolchain(&name, false))));
         println!("");
     }

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -542,3 +542,19 @@ fn delete_data_no_data() {
         assert!(!config.homedir.path().exists());
     });
 }
+
+// Regression test for newline placement
+#[test]
+fn update_all_no_update_whitespace() {
+    setup(&|config| {
+        expect_stdout_ok(config, &["multirust", "update", "nightly"],
+r"
+nightly revision:
+
+1.3.0 (hash-n-2)
+1.3.0 (hash-n-2)
+");
+    });
+}
+
+


### PR DESCRIPTION
Movement of println's in one bit of code caused regressions in
the display of other bits of code.