### PR TITLE
Overhaul the update UI

### DIFF
--- a/src/multirust-cli/common.rs
+++ b/src/multirust-cli/common.rs
@@ -100,12 +100,7 @@ pub fn run_inner<S: AsRef<OsStr>>(mut command: Command,
 }
 
 pub fn show_channel_version(cfg: &Cfg, name: &str) -> Result<()> {
-    let mut t = term::stdout().unwrap();
-    if tty::stdout_isatty() { let _ = t.fg(term::color::BRIGHT_WHITE); }
-    if tty::stdout_isatty() { let _ = t.bg(term::color::BLACK); }
-    let _ = write!(t, "{}", name);
-    if tty::stdout_isatty() { let _ = t.reset(); }
-    let _ = writeln!(t, " revision:");
+    println!("{} revision:", name);
     println!("");
     try!(show_tool_versions(&try!(cfg.get_toolchain(&name, false))));
     println!("");
@@ -122,7 +117,6 @@ pub fn show_channel_update(cfg: &Cfg, name: &str,
             let _ = write!(t, "{} updated", name);
         }
         Ok(false) => {
-            if tty { let _ = t.fg(term::color::BRIGHT_WHITE); }
             let _ = write!(t, "{} unchanged", name);
         }
         Err(_) => {

--- a/src/multirust-cli/common.rs
+++ b/src/multirust-cli/common.rs
@@ -1,12 +1,13 @@
 //! Just a dumping ground for cli stuff
 
-use multirust::{Cfg, Result, Notification, Toolchain, Error};
+use multirust::{Cfg, Result, Notification, Toolchain, Error, UpdateStatus};
 use multirust_utils::{self, utils};
 use multirust_utils::notify::NotificationLevel;
 use self_update;
 use std::ffi::OsStr;
 use std::io::{Write, Read, BufRead};
 use std::process::{self, Command};
+use std::{cmp, iter};
 use std;
 use tty;
 use term;
@@ -99,36 +100,58 @@ pub fn run_inner<S: AsRef<OsStr>>(mut command: Command,
     }
 }
 
-pub fn show_channel_version(cfg: &Cfg, name: &str) -> Result<()> {
-    println!("{} revision:", name);
-    println!("");
-    try!(show_tool_versions(&try!(cfg.get_toolchain(&name, false))));
-    println!("");
-    Ok(())
+pub fn show_channel_update(cfg: &Cfg, name: &str,
+                           updated: Result<UpdateStatus>) -> Result<()> {
+    show_channel_updates(cfg, vec![(name.to_string(), updated)])
 }
 
-pub fn show_channel_update(cfg: &Cfg, name: &str,
-                           updated: Result<bool>) -> Result<()> {
+fn show_channel_updates(cfg: &Cfg, toolchains: Vec<(String, Result<UpdateStatus>)>) -> Result<()> {
+    let data = toolchains.into_iter().map(|(name, result)| {
+        let ref toolchain = cfg.get_toolchain(&name, false).expect("");
+        let version = rustc_version(toolchain);
+
+        let banner;
+        let color;
+        match result {
+            Ok(UpdateStatus::Installed) => {
+                banner = format!("{} installed", name);
+                color = term::color::BRIGHT_GREEN;
+            }
+            Ok(UpdateStatus::Updated) => {
+                banner = format!("{} updated", name);
+                color = term::color::BRIGHT_GREEN;
+            }
+            Ok(UpdateStatus::Unchanged) => {
+                banner = format!("{} unchanged", name);
+                color = term::color::BRIGHT_CYAN;
+            }
+            Err(_) => {
+                banner = format!("{} update failed", name);
+                color = term::color::BRIGHT_RED;
+            }
+        }
+
+        (banner, color, version)
+    });
+
     let tty = tty::stdout_isatty();
     let mut t = term::stdout().unwrap();
-    match updated {
-        Ok(true) => {
-            if tty { let _ = t.fg(term::color::BRIGHT_GREEN); }
-            let _ = write!(t, "{} updated", name);
-        }
-        Ok(false) => {
-            let _ = write!(t, "{} unchanged", name);
-        }
-        Err(_) => {
-            if tty { let _ = t.fg(term::color::BRIGHT_RED); }
-            let _ = write!(t, "{} update failed", name);
-        }
+
+    let data: Vec<_> = data.collect();
+    let max_width = data.iter().fold(0, |a, &(ref b, _, _)| cmp::max(a, b.len()));
+
+    for (banner, color, version) in data {
+        let padding = max_width - banner.len();
+        let padding: String = iter::repeat(' ').take(padding).collect();
+        let _ = write!(t, "  {}", padding);
+
+        if tty { let _ = t.fg(color); }
+        let _ = write!(t, "{}", banner);
+        if tty { let _ = t.reset(); }
+        let _ = writeln!(t, ": {}", version);
     }
-    if tty {let _ = t.reset(); }
-    println!(":");
-    println!("");
-    try!(show_tool_versions(&try!(cfg.get_toolchain(&name, false))));
-    println!("");
+    let _ = writeln!(t, "");
+
     Ok(())
 }
 
@@ -149,9 +172,7 @@ pub fn update_all_channels(cfg: &Cfg, self_update: bool) -> Result<()> {
     if !toolchains.is_empty() {
         println!("");
 
-        for (name, result) in toolchains {
-            try!(show_channel_update(cfg, &name, result));
-        }
+        try!(show_channel_updates(cfg, toolchains));
     }
 
     if let Some(ref setup_path) = setup_path {
@@ -161,6 +182,32 @@ pub fn update_all_channels(cfg: &Cfg, self_update: bool) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn rustc_version(toolchain: &Toolchain) -> String {
+    if toolchain.exists() {
+        let rustc_path = toolchain.binary_file("rustc");
+        if utils::is_file(&rustc_path) {
+            let mut cmd = Command::new(&rustc_path);
+            cmd.arg("--version");
+            toolchain.set_ldpath(&mut cmd);
+
+            let out= cmd.output().ok();
+            let out = out.into_iter().filter(|o| o.status.success()).next();
+            let stdout = out.and_then(|o| String::from_utf8(o.stdout).ok());
+            let line1 = stdout.and_then(|o| o.lines().next().map(|l| l.to_owned()));
+
+            if let Some(line1) = line1 {
+                line1.to_owned()
+            } else {
+                String::from("(error reading rustc version)")
+            }
+        } else {
+            String::from("(rustc does not exist)")
+        }
+    } else {
+        String::from("(toolchain not installed)")
+    }
 }
 
 pub fn show_tool_versions(toolchain: &Toolchain) -> Result<()> {

--- a/src/multirust-cli/log.rs
+++ b/src/multirust-cli/log.rs
@@ -19,8 +19,9 @@ macro_rules! verbose {
 pub fn warn_fmt(args: fmt::Arguments) {
     let mut t = term::stderr().unwrap();
     if tty::stderr_isatty() { let _ = t.fg(term::color::BRIGHT_YELLOW); }
-    let _ = write!(t, "warning: ");
+    let _ = write!(t, "warning");
     if tty::stderr_isatty() { let _ = t.reset(); }
+    let _ = write!(t, ": ");
     let _ = t.write_fmt(args);
     let _ = write!(t, "\n");
 }
@@ -28,8 +29,9 @@ pub fn warn_fmt(args: fmt::Arguments) {
 pub fn err_fmt(args: fmt::Arguments) {
     let mut t = term::stderr().unwrap();
     if tty::stderr_isatty() { let _ = t.fg(term::color::BRIGHT_RED); }
-    let _ = write!(t, "error: ");
+    let _ = write!(t, "error");
     if tty::stderr_isatty() { let _ = t.reset(); }
+    let _ = write!(t, ": ");
     let _ = t.write_fmt(args);
     let _ = write!(t, "\n");
 }
@@ -37,8 +39,9 @@ pub fn err_fmt(args: fmt::Arguments) {
 pub fn info_fmt(args: fmt::Arguments) {
     let mut t = term::stderr().unwrap();
     if tty::stderr_isatty() { let _ = t.fg(term::color::BRIGHT_CYAN); }
-    let _ = write!(t, "info: ");
+    let _ = write!(t, "info");
     if tty::stderr_isatty() { let _ = t.reset(); }
+    let _ = write!(t, ": ");
     let _ = t.write_fmt(args);
     let _ = write!(t, "\n");
 }
@@ -46,8 +49,9 @@ pub fn info_fmt(args: fmt::Arguments) {
 pub fn verbose_fmt(args: fmt::Arguments) {
     let mut t = term::stderr().unwrap();
     if tty::stderr_isatty() { let _ = t.fg(term::color::BRIGHT_MAGENTA); }
-    let _ = write!(t, "verbose: ");
+    let _ = write!(t, "verbose");
     if tty::stderr_isatty() { let _ = t.reset(); }
+    let _ = write!(t, ": ");
     let _ = t.write_fmt(args);
     let _ = write!(t, "\n");
 }

--- a/src/multirust-cli/multirust_mode.rs
+++ b/src/multirust-cli/multirust_mode.rs
@@ -154,7 +154,7 @@ fn update(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
         println!("");
         try!(show_channel_version(cfg, name));
     } else {
-        try!(update_all_channels(cfg))
+        try!(update_all_channels(cfg, false))
     }
     Ok(())
 }

--- a/src/multirust-cli/multirust_mode.rs
+++ b/src/multirust-cli/multirust_mode.rs
@@ -1,8 +1,8 @@
 use clap::ArgMatches;
 use cli;
-use common::{self, confirm, show_channel_version,
-             set_globals, run_inner,
-             show_tool_versions, update_all_channels};
+use common::{self, confirm, set_globals, run_inner,
+             show_channel_update, show_tool_versions,
+             update_all_channels};
 use multirust::*;
 use multirust_dist::manifest::Component;
 use self_update;
@@ -126,17 +126,24 @@ fn remove_toolchain_args(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
 
 fn default_(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
     let toolchain = try!(get_toolchain(cfg, m, true));
-    if !try!(common_install_args(&toolchain, m)) {
+    let status = if !try!(common_install_args(&toolchain, m)) {
         if !toolchain.is_custom() {
-            try!(toolchain.install_from_dist_if_not_installed());
+            Some(try!(toolchain.install_from_dist_if_not_installed()))
         } else if !toolchain.exists() {
             return Err(Error::ToolchainNotInstalled(toolchain.name().to_string()));
+        } else {
+            None
         }
-    }
+    } else {
+        None
+    };
 
     try!(toolchain.make_default());
-    println!("");
-    try!(show_channel_version(cfg, toolchain.name()));
+
+    if let Some(status) = status {
+        println!("");
+        try!(show_channel_update(cfg, toolchain.name(), Ok(status)));
+    }
 
     Ok(())
 }
@@ -144,15 +151,22 @@ fn default_(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
 fn update(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
     if let Some(name) = m.value_of("toolchain") {
         let toolchain = try!(cfg.get_toolchain(name, true));
-        if !try!(common_install_args(&toolchain, m)) {
+        let status = if !try!(common_install_args(&toolchain, m)) {
             if !toolchain.is_custom() {
-                try!(toolchain.install_from_dist());
+                Some(try!(toolchain.install_from_dist()))
             } else if !toolchain.exists() {
                 return Err(Error::ToolchainNotInstalled(toolchain.name().to_string()));
+            } else {
+                None
             }
+        } else {
+            None
+        };
+
+        if let Some(status) = status {
+            println!("");
+            try!(show_channel_update(cfg, name, Ok(status)));
         }
-        println!("");
-        try!(show_channel_version(cfg, name));
     } else {
         try!(update_all_channels(cfg, false))
     }
@@ -161,15 +175,23 @@ fn update(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
 
 fn override_(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
     let toolchain = try!(get_toolchain(cfg, m, true));
-    if !try!(common_install_args(&toolchain, m)) {
+    let status = if !try!(common_install_args(&toolchain, m)) {
         if !toolchain.is_custom() {
-            try!(toolchain.install_from_dist_if_not_installed());
+            Some(try!(toolchain.install_from_dist_if_not_installed()))
+        } else {
+            None
         }
-    }
+    } else {
+        None
+    };
 
     try!(toolchain.make_override(&try!(utils::current_dir())));
-    println!("");
-    try!(show_channel_version(cfg, toolchain.name()));
+
+    if let Some(status) = status {
+        println!("");
+        try!(show_channel_update(cfg, toolchain.name(), Ok(status)));
+    }
+
     Ok(())
 }
 

--- a/src/multirust-cli/rustup_mode.rs
+++ b/src/multirust-cli/rustup_mode.rs
@@ -51,7 +51,7 @@ pub fn main() -> Result<()> {
             }
         }
         (_, _) => {
-            try!(update_all_channels(cfg));
+            try!(update_all_channels(cfg, &matches));
         }
     }
 
@@ -66,9 +66,14 @@ pub fn cli() -> App<'static, 'static> {
         .setting(AppSettings::VersionlessSubcommands)
         .setting(AppSettings::DeriveDisplayOrder)
         .arg(Arg::with_name("verbose")
+            .help("Enable verbose output")
             .short("v")
-            .long("verbose")
-            .help("Enable verbose output"))
+            .long("verbose"))
+        .arg(Arg::with_name("no-self-update")
+            .help("Don't perf self update when running the `rustup` command")
+            .long("no-self-update")
+            .takes_value(false)
+            .hidden(true))
         .subcommand(SubCommand::with_name("default")
             .about("Set the default toolchain")
             .arg(Arg::with_name("toolchain")
@@ -133,8 +138,8 @@ pub fn cli() -> App<'static, 'static> {
                 .about("Upgrade the internal data format.")))
 }
 
-fn update_all_channels(cfg: &Cfg) -> Result<()> {
-    common::update_all_channels(cfg)
+fn update_all_channels(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
+    common::update_all_channels(cfg, !m.is_present("no-self-update"))
 }
 
 fn default_(cfg: &Cfg, m: &ArgMatches) -> Result<()> {

--- a/src/multirust-cli/self_update.rs
+++ b/src/multirust-cli/self_update.rs
@@ -790,6 +790,17 @@ fn do_remove_from_path(methods: &[PathUpdateMethod]) -> Result<()> {
 /// multirust-setup is stored in CARGO_HOME/bin, and then deleted next
 /// time multirust runs.
 pub fn update() -> Result<()> {
+
+    let setup_path = try!(prepare_update());
+    if let Some(ref p) = setup_path {
+        info!("multirust updated successfully");
+        try!(run_update(p));
+    }
+
+    Ok(())
+}
+
+pub fn prepare_update() -> Result<Option<PathBuf>> {
     let ref cargo_home = try!(utils::cargo_home());
     let ref multirust_path = cargo_home.join(&format!("bin/multirust{}", EXE_SUFFIX));
     let ref setup_path = cargo_home.join(&format!("bin/multirust-setup{}", EXE_SUFFIX));
@@ -826,7 +837,7 @@ pub fn update() -> Result<()> {
                              .join("");
 
     // Download latest hash
-    info!("checking for updates");
+    info!("checking for self-updates");
     let hash_url = try!(utils::parse_url(&(url.clone() + ".sha256")));
     let hash_file = tempdir.path().join("hash");
     try!(utils::download_file(hash_url, &hash_file, None, ntfy!(&NotifyHandler::none())));
@@ -836,14 +847,14 @@ pub fn update() -> Result<()> {
     // If up-to-date
     if latest_hash == current_hash {
         info!("multirust is already up to date");
-        return Ok(());
+        return Ok(None);
     }
 
     // Get download path
     let download_url = try!(utils::parse_url(&url));
 
     // Download new version
-    info!("downloading update");
+    info!("downloading self-update");
     let mut hasher = Hasher::new(Type::SHA256);
     try!(utils::download_file(download_url,
                               &setup_path,
@@ -866,26 +877,19 @@ pub fn update() -> Result<()> {
     // Mark as executable
     try!(utils::make_executable(setup_path));
 
-    // FIXME: Before doing the final step of replacing the bins, give
-    // the updater a chance to display messages and do data upgrades.
-
-    // Tell the upgrader to replace the multirust bins, then delete
-    // itself. Like with uninstallation, on Windows we're going to
-    // have to jump through hoops to make everything work right.
-    //
-    // On windows we're not going to wait for it to finish before exiting
-    // successfully, so it should not do much, and it should try
-    // really hard to succeed, because at this point the upgrade is
-    // considered successful.
-    try!(run_update(setup_path));
-
-    info!("multirust updated successfully");
-
-    process::exit(0);
+    Ok(Some(setup_path.to_owned()))
 }
 
+/// Tell the upgrader to replace the multirust bins, then delete
+/// itself. Like with uninstallation, on Windows we're going to
+/// have to jump through hoops to make everything work right.
+///
+/// On windows we're not going to wait for it to finish before exiting
+/// successfully, so it should not do much, and it should try
+/// really hard to succeed, because at this point the upgrade is
+/// considered successful.
 #[cfg(unix)]
-fn run_update(setup_path: &Path) -> Result<()> {
+pub fn run_update(setup_path: &Path) -> Result<()> {
     let status = try!(Command::new(setup_path)
         .arg("--self-replace")
         .status().map_err(|_| Error::Custom {
@@ -897,11 +901,11 @@ fn run_update(setup_path: &Path) -> Result<()> {
         return Err(Error::SelfUpdateFailed);
     }
 
-    Ok(())
+    process::exit(0);
 }
 
 #[cfg(windows)]
-fn run_update(setup_path: &Path) -> Result<()> {
+pub fn run_update(setup_path: &Path) -> Result<()> {
     try!(Command::new(setup_path)
         .arg("--self-replace")
         .spawn().map_err(|_| Error::Custom {
@@ -909,7 +913,7 @@ fn run_update(setup_path: &Path) -> Result<()> {
             desc: "unable to run updater".to_string(),
         }));
 
-    Ok(())
+    process::exit(0);
 }
 
 /// This function is as the final step of a self-upgrade. It replaces

--- a/src/multirust-cli/self_update.rs
+++ b/src/multirust-cli/self_update.rs
@@ -294,10 +294,10 @@ fn maybe_install_rust_stable(verbose: bool) -> Result<()> {
     // then install stable and make it the default.
     if try!(cfg.find_default()).is_none() {
         let stable = try!(cfg.get_toolchain("stable", false));
-        try!(stable.install_from_dist());
+        let status = try!(stable.install_from_dist());
         try!(cfg.set_default("stable"));
         println!("");
-        try!(common::show_channel_version(cfg, "stable"));
+        try!(common::show_channel_update(cfg, "stable", Ok(status)));
     } else {
         info!("updating existing installation");
     }

--- a/src/multirust-dist/src/dist.rs
+++ b/src/multirust-dist/src/dist.rs
@@ -279,6 +279,7 @@ pub fn update_from_dist<'a>(download: DownloadCfg<'a>,
                             remove: &[Component],
                             ) -> Result<Option<String>> {
 
+    let toolchain_str = toolchain;
     let ref toolchain = try!(ToolchainDesc::from_str(toolchain));
     let trip = toolchain.target_triple();
     let manifestation = try!(Manifestation::open(prefix.clone(), &trip));
@@ -289,7 +290,7 @@ pub fn update_from_dist<'a>(download: DownloadCfg<'a>,
     };
 
     // TODO: Add a notification about which manifest version is going to be used
-    download.notify_handler.call(Notification::DownloadingManifest);
+    download.notify_handler.call(Notification::DownloadingManifest(toolchain_str));
     match dl_v2_manifest(download, update_hash, toolchain) {
         Ok(Some((m, hash))) => {
             return match try!(manifestation.update(&m, changes, &download.temp_cfg,

--- a/src/multirust-dist/src/errors.rs
+++ b/src/multirust-dist/src/errors.rs
@@ -26,7 +26,7 @@ pub enum Notification<'a> {
     MissingInstalledComponent(&'a str),
     DownloadingComponent(&'a str),
     InstallingComponent(&'a str),
-    DownloadingManifest,
+    DownloadingManifest(&'a str),
     DownloadingLegacyManifest,
 }
 
@@ -104,7 +104,7 @@ impl<'a> Notification<'a> {
             DownloadingComponent(_) |
             InstallingComponent(_) |
             ComponentAlreadyInstalled(_)  |
-            RollingBack | DownloadingManifest => NotificationLevel::Info,
+            RollingBack | DownloadingManifest(_) => NotificationLevel::Info,
             CantReadUpdateHash(_) | ExtensionNotInstalled(_) |
             MissingInstalledComponent(_) => NotificationLevel::Warn,
             NonFatalError(_) => NotificationLevel::Error,
@@ -139,7 +139,7 @@ impl<'a> Display for Notification<'a> {
             MissingInstalledComponent(c) => write!(f, "during uninstall component {} was not found", c),
             DownloadingComponent(c) => write!(f, "downloading component '{}'", c),
             InstallingComponent(c) => write!(f, "installing component '{}'", c),
-            DownloadingManifest => write!(f, "downloading toolchain manifest"),
+            DownloadingManifest(t) => write!(f, "syncing channel updates for '{}'", t),
             DownloadingLegacyManifest => write!(f, "manifest not found. trying legacy manifest"),
         }
     }

--- a/src/multirust-mock/src/clitools.rs
+++ b/src/multirust-mock/src/clitools.rs
@@ -22,7 +22,7 @@ pub struct Config {
     /// The distribution server
     pub distdir: TempDir,
     /// MULTIRUST_HOME
-    pub homedir: TempDir,
+    pub rustupdir: TempDir,
     /// Custom toolchains
     pub customdir: TempDir,
 }
@@ -47,7 +47,7 @@ pub fn setup(s: Scenario, f: &Fn(&Config)) {
     let ref config = Config {
         exedir: TempDir::new("multirust").unwrap(),
         distdir: TempDir::new("multirust").unwrap(),
-        homedir: TempDir::new("multirust").unwrap(),
+        rustupdir: TempDir::new("multirust").unwrap(),
         customdir: TempDir::new("multirust").unwrap(),
     };
 
@@ -172,7 +172,7 @@ pub fn cmd(config: &Config, name: &str, args: &[&str]) -> Command {
 }
 
 pub fn env(config: &Config, cmd: &mut Command) {
-    cmd.env("MULTIRUST_HOME", config.homedir.path().to_string_lossy().to_string());
+    cmd.env("MULTIRUST_HOME", config.rustupdir.path().to_string_lossy().to_string());
     cmd.env("MULTIRUST_DIST_ROOT", format!("file://{}", config.distdir.path().join("dist").to_string_lossy()));
 }
 

--- a/src/multirust-mock/src/clitools.rs
+++ b/src/multirust-mock/src/clitools.rs
@@ -100,6 +100,12 @@ pub fn setup(s: Scenario, f: &Fn(&Config)) {
     let _g = LOCK.lock();
 
     f(config);
+
+    // These are the bogus values the test harness sets "HOME" and "CARGO_HOME"
+    // to during testing. If they exist that means a test unexpectedly used
+    // one of these environment variables.
+    assert!(!PathBuf::from("./bogus-home").exists());
+    assert!(!PathBuf::from("./bogus-cargo-home").exists());
 }
 
 /// Change the current distribution manifest to a particular date

--- a/src/multirust/config.rs
+++ b/src/multirust/config.rs
@@ -11,7 +11,7 @@ use errors::*;
 use multirust_dist::{temp, dist};
 use multirust_utils::utils;
 use override_db::OverrideDB;
-use toolchain::Toolchain;
+use toolchain::{Toolchain, UpdateStatus};
 
 // Note: multirust-rs jumped from 2 to 12 to leave multirust.sh room to diverge
 pub const METADATA_VERSION: &'static str = "12";
@@ -261,7 +261,7 @@ impl Cfg {
         }
     }
 
-    pub fn update_all_channels(&self) -> Result<Vec<(String, Result<bool>)>> {
+    pub fn update_all_channels(&self) -> Result<Vec<(String, Result<UpdateStatus>)>> {
         let toolchains = try!(self.list_toolchains());
 
         let mut toolchains: Vec<(dist::ToolchainDesc, String)> = toolchains.into_iter()

--- a/src/multirust/errors.rs
+++ b/src/multirust/errors.rs
@@ -89,19 +89,19 @@ impl<'a> Notification<'a> {
             ToolchainDirectory(_, _) |
             LookingForToolchain(_) |
             WritingMetadataVersion(_) |
-            ReadMetadataVersion(_) => NotificationLevel::Verbose,
+            InstallingToolchain(_) |
+            UpdatingToolchain(_) |
+            ReadMetadataVersion(_) |
+            InstalledToolchain(_) |
+            UpdateHashMatches => NotificationLevel::Verbose,
             SetDefaultToolchain(_) |
             SetOverrideToolchain(_, _) |
-            UpdatingToolchain(_) |
-            InstallingToolchain(_) |
-            InstalledToolchain(_) |
             UsingExistingToolchain(_) |
             UninstallingToolchain(_) |
             UninstalledToolchain(_) |
             ToolchainNotInstalled(_) |
             UpgradingMetadata(_, _) |
-            MetadataUpgradeNotNeeded(_) |
-            UpdateHashMatches => NotificationLevel::Info,
+            MetadataUpgradeNotNeeded(_)  => NotificationLevel::Info,
             NonFatalError(_) => NotificationLevel::Error,
             UpgradeRemovesToolchains |
             MissingFileDuringSelfUninstall(_) => NotificationLevel::Warn,

--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -145,12 +145,12 @@ error: no release found for 'nightly-2016-01-01'
 fn delete_data() {
     setup(&|config| {
         expect_ok(config, &["multirust", "default", "nightly"]);
-        assert!(config.rustupdir.path().exists());
+        assert!(config.rustupdir.exists());
         expect_ok_ex(config, &["multirust", "delete-data", "-y"],
 r"",
 &format!(
 r"info: deleted directory '{}'
-", config.rustupdir.path().display()));
+", config.rustupdir.display()));
     });
 }
 

--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -19,14 +19,10 @@ fn update() {
     setup(&|config| {
         expect_ok_ex(config, &["multirust", "update", "nightly"],
 r"
-nightly revision:
-
-1.3.0 (hash-n-2)
-1.3.0 (hash-n-2)
+  nightly installed: 1.3.0 (hash-n-2)
 
 ",
-r"info: installing toolchain 'nightly'
-info: downloading toolchain manifest
+r"info: syncing channel updates for 'nightly'
 info: downloading component 'rust-std'
 info: downloading component 'rustc'
 info: downloading component 'cargo'
@@ -35,7 +31,6 @@ info: installing component 'rust-std'
 info: installing component 'rustc'
 info: installing component 'cargo'
 info: installing component 'rust-docs'
-info: toolchain 'nightly' installed
 ");
     });
 }
@@ -46,15 +41,10 @@ fn update_again() {
         expect_ok(config, &["multirust", "update", "nightly"]);
         expect_ok_ex(config, &["multirust", "update", "nightly"],
 r"
-nightly revision:
-
-1.3.0 (hash-n-2)
-1.3.0 (hash-n-2)
+  nightly unchanged: 1.3.0 (hash-n-2)
 
 ",
-r"info: updating existing install for 'nightly'
-info: downloading toolchain manifest
-info: toolchain is already up to date
+r"info: syncing channel updates for 'nightly'
 ");
     });
 }
@@ -64,14 +54,10 @@ fn default() {
     setup(&|config| {
         expect_ok_ex(config, &["multirust", "default", "nightly"],
 r"
-nightly revision:
-
-1.3.0 (hash-n-2)
-1.3.0 (hash-n-2)
+  nightly installed: 1.3.0 (hash-n-2)
 
 ",
-r"info: installing toolchain 'nightly'
-info: downloading toolchain manifest
+r"info: syncing channel updates for 'nightly'
 info: downloading component 'rust-std'
 info: downloading component 'rustc'
 info: downloading component 'cargo'
@@ -80,7 +66,6 @@ info: installing component 'rust-std'
 info: installing component 'rustc'
 info: installing component 'cargo'
 info: installing component 'rust-docs'
-info: toolchain 'nightly' installed
 info: default toolchain set to 'nightly'
 ");
     });
@@ -93,10 +78,7 @@ fn override_again() {
         expect_ok(config, &["multirust", "override", "nightly"]);
         expect_ok_ex(config, &["multirust", "override", "nightly"],
 r"
-nightly revision:
-
-1.3.0 (hash-n-2)
-1.3.0 (hash-n-2)
+  nightly unchanged: 1.3.0 (hash-n-2)
 
 ",
 &format!(
@@ -134,8 +116,7 @@ fn update_no_manifest() {
     setup(&|config| {
         expect_err_ex(config, &["multirust", "update", "nightly-2016-01-01"],
 r"",
-r"info: installing toolchain 'nightly-2016-01-01'
-info: downloading toolchain manifest
+r"info: syncing channel updates for 'nightly-2016-01-01'
 error: no release found for 'nightly-2016-01-01'
 ");
     });

--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -145,12 +145,12 @@ error: no release found for 'nightly-2016-01-01'
 fn delete_data() {
     setup(&|config| {
         expect_ok(config, &["multirust", "default", "nightly"]);
-        assert!(config.homedir.path().exists());
+        assert!(config.rustupdir.path().exists());
         expect_ok_ex(config, &["multirust", "delete-data", "-y"],
 r"",
 &format!(
 r"info: deleted directory '{}'
-", config.homedir.path().display()));
+", config.rustupdir.path().display()));
     });
 }
 

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -42,7 +42,7 @@ fn rustc_with_bad_multirust_toolchain_env_var() {
 #[test]
 fn install_toolchain_linking_from_path() {
     setup(&|config| {
-        let path = config.customdir.path().join("custom-1");
+        let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "default", "default-from-path",
                             "--link-local", &path]);
@@ -54,7 +54,7 @@ fn install_toolchain_linking_from_path() {
 #[test]
 fn install_toolchain_from_path() {
     setup(&|config| {
-        let path = config.customdir.path().join("custom-1");
+        let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "default", "default-from-path",
                             "--copy-local", &path]);
@@ -66,13 +66,13 @@ fn install_toolchain_from_path() {
 #[test]
 fn install_toolchain_linking_from_path_again() {
     setup(&|config| {
-        let path = config.customdir.path().join("custom-1");
+        let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "default", "default-from-path",
                             "--link-local", &path]);
         expect_stdout_ok(config, &["rustc", "--version"],
                          "hash-c-1");
-        let path = config.customdir.path().join("custom-2");
+        let path = config.customdir.join("custom-2");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "default", "default-from-path",
                             "--link-local", &path]);
@@ -84,13 +84,13 @@ fn install_toolchain_linking_from_path_again() {
 #[test]
 fn install_toolchain_from_path_again() {
     setup(&|config| {
-        let path = config.customdir.path().join("custom-1");
+        let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "default", "default-from-path",
                             "--copy-local", &path]);
         expect_stdout_ok(config, &["rustc", "--version"],
                          "hash-c-1");
-        let path = config.customdir.path().join("custom-2");
+        let path = config.customdir.join("custom-2");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "default", "default-from-path",
                             "--copy-local", &path]);
@@ -102,13 +102,13 @@ fn install_toolchain_from_path_again() {
 #[test]
 fn install_toolchain_change_from_copy_to_link() {
     setup(&|config| {
-        let path = config.customdir.path().join("custom-1");
+        let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "default", "default-from-path",
                             "--copy-local", &path]);
         expect_stdout_ok(config, &["rustc", "--version"],
                          "hash-c-1");
-        let path = config.customdir.path().join("custom-2");
+        let path = config.customdir.join("custom-2");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "default", "default-from-path",
                             "--link-local", &path]);
@@ -120,13 +120,13 @@ fn install_toolchain_change_from_copy_to_link() {
 #[test]
 fn install_toolchain_change_from_link_to_copy() {
     setup(&|config| {
-        let path = config.customdir.path().join("custom-1");
+        let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "default", "default-from-path",
                             "--link-local", &path]);
         expect_stdout_ok(config, &["rustc", "--version"],
                          "hash-c-1");
-        let path = config.customdir.path().join("custom-2");
+        let path = config.customdir.join("custom-2");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "default", "default-from-path",
                             "--copy-local", &path]);
@@ -139,7 +139,7 @@ fn install_toolchain_change_from_link_to_copy() {
 fn install_toolchain_from_custom() {
     setup(&|config| {
         let trip = this_host_triple();
-        let custom_installer = config.distdir.path().join(
+        let custom_installer = config.distdir.join(
             format!("dist/rust-nightly-{}.tar.gz", trip));
         let custom_installer = custom_installer.to_string_lossy();
         expect_ok(config, &["multirust", "default", "custom",
@@ -153,7 +153,7 @@ fn install_toolchain_from_custom() {
 fn install_toolchain_from_custom_wrong_extension() {
     setup(&|config| {
         let trip = this_host_triple();
-        let custom_installer = config.distdir.path().join(
+        let custom_installer = config.distdir.join(
             format!("dist/rust-nightly-{}.msi", trip));
         let custom_installer = custom_installer.to_string_lossy();
         expect_err(config, &["multirust", "default", "custom",
@@ -165,7 +165,7 @@ fn install_toolchain_from_custom_wrong_extension() {
 #[test]
 fn install_override_toolchain_linking_from_path() {
     setup(&|config| {
-        let path = config.customdir.path().join("custom-1");
+        let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "override", "default-from-path",
                             "--link-local", &path]);
@@ -177,7 +177,7 @@ fn install_override_toolchain_linking_from_path() {
 #[test]
 fn install_override_toolchain_from_path() {
     setup(&|config| {
-        let path = config.customdir.path().join("custom-1");
+        let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "override", "default-from-path",
                             "--copy-local", &path]);
@@ -189,13 +189,13 @@ fn install_override_toolchain_from_path() {
 #[test]
 fn install_override_toolchain_linking_from_path_again() {
     setup(&|config| {
-        let path = config.customdir.path().join("custom-1");
+        let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "override", "default-from-path",
                             "--link-local", &path]);
         expect_stdout_ok(config, &["rustc", "--version"],
                          "hash-c-1");
-        let path = config.customdir.path().join("custom-2");
+        let path = config.customdir.join("custom-2");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "override", "default-from-path",
                             "--link-local", &path]);
@@ -207,13 +207,13 @@ fn install_override_toolchain_linking_from_path_again() {
 #[test]
 fn install_override_toolchain_from_path_again() {
     setup(&|config| {
-        let path = config.customdir.path().join("custom-1");
+        let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "override", "default-from-path",
                             "--copy-local", &path]);
         expect_stdout_ok(config, &["rustc", "--version"],
                          "hash-c-1");
-        let path = config.customdir.path().join("custom-2");
+        let path = config.customdir.join("custom-2");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "override", "default-from-path",
                             "--copy-local", &path]);
@@ -225,13 +225,13 @@ fn install_override_toolchain_from_path_again() {
 #[test]
 fn install_override_toolchain_change_from_copy_to_link() {
     setup(&|config| {
-        let path = config.customdir.path().join("custom-1");
+        let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "default", "default-from-path",
                             "--copy-local", &path]);
         expect_stdout_ok(config, &["rustc", "--version"],
                          "hash-c-1");
-        let path = config.customdir.path().join("custom-2");
+        let path = config.customdir.join("custom-2");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "default", "default-from-path",
                             "--link-local", &path]);
@@ -243,13 +243,13 @@ fn install_override_toolchain_change_from_copy_to_link() {
 #[test]
 fn install_override_toolchain_change_from_link_to_copy() {
     setup(&|config| {
-        let path = config.customdir.path().join("custom-1");
+        let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "default", "default-from-path",
                             "--link-local", &path]);
         expect_stdout_ok(config, &["rustc", "--version"],
                          "hash-c-1");
-        let path = config.customdir.path().join("custom-2");
+        let path = config.customdir.join("custom-2");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "default", "default-from-path",
                             "--copy-local", &path]);
@@ -262,7 +262,7 @@ fn install_override_toolchain_change_from_link_to_copy() {
 fn install_override_toolchain_from_custom() {
     setup(&|config| {
         let trip = this_host_triple();
-        let custom_installer = config.distdir.path().join(
+        let custom_installer = config.distdir.join(
             format!("dist/rust-nightly-{}.tar.gz", trip));
         let custom_installer = custom_installer.to_string_lossy();
         expect_ok(config, &["multirust", "override", "custom",
@@ -275,7 +275,7 @@ fn install_override_toolchain_from_custom() {
 #[test]
 fn update_toolchain_linking_from_path() {
     setup(&|config| {
-        let path = config.customdir.path().join("custom-1");
+        let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "update", "default-from-path",
                             "--link-local", &path]);
@@ -288,7 +288,7 @@ fn update_toolchain_linking_from_path() {
 #[test]
 fn update_toolchain_from_path() {
     setup(&|config| {
-        let path = config.customdir.path().join("custom-1");
+        let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "update", "default-from-path",
                             "--copy-local", &path]);
@@ -301,14 +301,14 @@ fn update_toolchain_from_path() {
 #[test]
 fn update_toolchain_linking_from_path_again() {
     setup(&|config| {
-        let path = config.customdir.path().join("custom-1");
+        let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "update", "default-from-path",
                             "--link-local", &path]);
         expect_ok(config, &["multirust", "default", "default-from-path"]);
         expect_stdout_ok(config, &["rustc", "--version"],
                          "hash-c-1");
-        let path = config.customdir.path().join("custom-2");
+        let path = config.customdir.join("custom-2");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "update", "default-from-path",
                             "--link-local", &path]);
@@ -320,14 +320,14 @@ fn update_toolchain_linking_from_path_again() {
 #[test]
 fn update_toolchain_from_path_again() {
     setup(&|config| {
-        let path = config.customdir.path().join("custom-1");
+        let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "update", "default-from-path",
                             "--copy-local", &path]);
         expect_ok(config, &["multirust", "default", "default-from-path"]);
         expect_stdout_ok(config, &["rustc", "--version"],
                          "hash-c-1");
-        let path = config.customdir.path().join("custom-2");
+        let path = config.customdir.join("custom-2");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "update", "default-from-path",
                             "--copy-local", &path]);
@@ -339,14 +339,14 @@ fn update_toolchain_from_path_again() {
 #[test]
 fn update_toolchain_change_from_copy_to_link() {
     setup(&|config| {
-        let path = config.customdir.path().join("custom-1");
+        let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "update", "default-from-path",
                             "--copy-local", &path]);
         expect_ok(config, &["multirust", "default", "default-from-path"]);
         expect_stdout_ok(config, &["rustc", "--version"],
                          "hash-c-1");
-        let path = config.customdir.path().join("custom-2");
+        let path = config.customdir.join("custom-2");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "update", "default-from-path",
                             "--link-local", &path]);
@@ -358,14 +358,14 @@ fn update_toolchain_change_from_copy_to_link() {
 #[test]
 fn update_toolchain_change_from_link_to_copy() {
     setup(&|config| {
-        let path = config.customdir.path().join("custom-1");
+        let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "update", "default-from-path",
                             "--link-local", &path]);
         expect_ok(config, &["multirust", "default", "default-from-path"]);
         expect_stdout_ok(config, &["rustc", "--version"],
                          "hash-c-1");
-        let path = config.customdir.path().join("custom-2");
+        let path = config.customdir.join("custom-2");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "update", "default-from-path",
                             "--copy-local", &path]);
@@ -432,7 +432,7 @@ fn invalid_names_with_copy_local() {
 fn custom_remote_url() {
     setup(&|config| {
         let trip = this_host_triple();
-        let custom_installer = config.distdir.path().join(
+        let custom_installer = config.distdir.join(
             format!("dist/rust-nightly-{}.tar.gz", trip));
         let custom_installer = custom_installer.to_string_lossy();
         let custom_installer = format!("file://{}", custom_installer);
@@ -447,10 +447,10 @@ fn custom_remote_url() {
 fn custom_multiple_local_path() {
     clitools::setup(Scenario::Full, &|config| {
         let trip = this_host_triple();
-        let custom_installer1 = config.distdir.path().join(
+        let custom_installer1 = config.distdir.join(
             format!("dist/2015-01-01/rustc-nightly-{}.tar.gz", trip));
         let custom_installer1 = custom_installer1.to_string_lossy();
-        let custom_installer2 = config.distdir.path().join(
+        let custom_installer2 = config.distdir.join(
             format!("dist/2015-01-01/cargo-nightly-{}.tar.gz", trip));
         let custom_installer2 = custom_installer2.to_string_lossy();
         expect_ok(config, &["multirust", "default", "custom",
@@ -467,11 +467,11 @@ fn custom_multiple_local_path() {
 fn custom_multiple_remote_url() {
     clitools::setup(Scenario::Full, &|config| {
         let trip = this_host_triple();
-        let custom_installer1 = config.distdir.path().join(
+        let custom_installer1 = config.distdir.join(
             format!("dist/2015-01-01/rustc-nightly-{}.tar.gz", trip));
         let custom_installer1 = custom_installer1.to_string_lossy();
         let custom_installer1 = format!("file://{}", custom_installer1);
-        let custom_installer2 = config.distdir.path().join(
+        let custom_installer2 = config.distdir.join(
             format!("dist/2015-01-01/cargo-nightly-{}.tar.gz", trip));
         let custom_installer2 = custom_installer2.to_string_lossy();
         let custom_installer2 = format!("file://{}", custom_installer2);
@@ -490,7 +490,7 @@ fn running_with_v2_metadata() {
     setup(&|config| {
         expect_ok(config, &["multirust", "default", "nightly"]);
         // Replace the metadata version
-        multirust_utils::raw::write_file(&config.rustupdir.path().join("version"),
+        multirust_utils::raw::write_file(&config.rustupdir.join("version"),
                                "2").unwrap();
         expect_err(config, &["multirust", "default", "nightly"],
                    "multirust's metadata is out of date. run multirust upgrade-data");
@@ -507,7 +507,7 @@ fn upgrade_v2_metadata_to_v12() {
     setup(&|config| {
         expect_ok(config, &["multirust", "default", "nightly"]);
         // Replace the metadata version
-        multirust_utils::raw::write_file(&config.rustupdir.path().join("version"),
+        multirust_utils::raw::write_file(&config.rustupdir.join("version"),
                                "2").unwrap();
         expect_stderr_ok(config, &["multirust", "upgrade-data"],
                          "warning: this upgrade will remove all existing toolchains. you will need to reinstall them");
@@ -525,9 +525,9 @@ fn upgrade_v2_metadata_to_v12() {
 fn delete_data() {
     setup(&|config| {
         expect_ok(config, &["multirust", "default", "nightly"]);
-        assert!(config.rustupdir.path().exists());
+        assert!(config.rustupdir.exists());
         expect_ok(config, &["multirust", "delete-data", "-y"]);
-        assert!(!config.rustupdir.path().exists());
+        assert!(!config.rustupdir.exists());
     });
 }
 
@@ -535,11 +535,11 @@ fn delete_data() {
 fn delete_data_no_data() {
     setup(&|config| {
         expect_ok(config, &["multirust", "default", "nightly"]);
-        assert!(config.rustupdir.path().exists());
+        assert!(config.rustupdir.exists());
         expect_ok(config, &["multirust", "delete-data", "-y"]);
-        assert!(!config.rustupdir.path().exists());
+        assert!(!config.rustupdir.exists());
         expect_ok(config, &["multirust", "delete-data", "-y"]);
-        assert!(!config.rustupdir.path().exists());
+        assert!(!config.rustupdir.exists());
     });
 }
 

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -549,10 +549,8 @@ fn update_all_no_update_whitespace() {
     setup(&|config| {
         expect_stdout_ok(config, &["multirust", "update", "nightly"],
 r"
-nightly revision:
+  nightly installed: 1.3.0 (hash-n-2)
 
-1.3.0 (hash-n-2)
-1.3.0 (hash-n-2)
 ");
     });
 }

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -490,7 +490,7 @@ fn running_with_v2_metadata() {
     setup(&|config| {
         expect_ok(config, &["multirust", "default", "nightly"]);
         // Replace the metadata version
-        multirust_utils::raw::write_file(&config.homedir.path().join("version"),
+        multirust_utils::raw::write_file(&config.rustupdir.path().join("version"),
                                "2").unwrap();
         expect_err(config, &["multirust", "default", "nightly"],
                    "multirust's metadata is out of date. run multirust upgrade-data");
@@ -507,7 +507,7 @@ fn upgrade_v2_metadata_to_v12() {
     setup(&|config| {
         expect_ok(config, &["multirust", "default", "nightly"]);
         // Replace the metadata version
-        multirust_utils::raw::write_file(&config.homedir.path().join("version"),
+        multirust_utils::raw::write_file(&config.rustupdir.path().join("version"),
                                "2").unwrap();
         expect_stderr_ok(config, &["multirust", "upgrade-data"],
                          "warning: this upgrade will remove all existing toolchains. you will need to reinstall them");
@@ -525,9 +525,9 @@ fn upgrade_v2_metadata_to_v12() {
 fn delete_data() {
     setup(&|config| {
         expect_ok(config, &["multirust", "default", "nightly"]);
-        assert!(config.homedir.path().exists());
+        assert!(config.rustupdir.path().exists());
         expect_ok(config, &["multirust", "delete-data", "-y"]);
-        assert!(!config.homedir.path().exists());
+        assert!(!config.rustupdir.path().exists());
     });
 }
 
@@ -535,11 +535,11 @@ fn delete_data() {
 fn delete_data_no_data() {
     setup(&|config| {
         expect_ok(config, &["multirust", "default", "nightly"]);
-        assert!(config.homedir.path().exists());
+        assert!(config.rustupdir.path().exists());
         expect_ok(config, &["multirust", "delete-data", "-y"]);
-        assert!(!config.homedir.path().exists());
+        assert!(!config.rustupdir.path().exists());
         expect_ok(config, &["multirust", "delete-data", "-y"]);
-        assert!(!config.homedir.path().exists());
+        assert!(!config.rustupdir.path().exists());
     });
 }
 

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -20,9 +20,9 @@ pub fn setup(f: &Fn(&Config)) {
 fn rustup_stable() {
     setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup-setup", "-y"]);
+        expect_ok(config, &["rustup", "update", "stable"]);
         set_current_dist_date(config, "2015-01-02");
-        expect_ok_ex(config, &["rustup"],
+        expect_ok_ex(config, &["rustup", "--no-self-update"],
 r"
 stable updated:
 
@@ -49,8 +49,8 @@ info: toolchain 'stable' installed
 fn rustup_stable_no_change() {
     setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup-setup", "-y"]);
-        expect_ok_ex(config, &["rustup"],
+        expect_ok(config, &["rustup", "update", "stable"]);
+        expect_ok_ex(config, &["rustup", "--no-self-update"],
 r"
 stable unchanged:
 
@@ -69,11 +69,11 @@ info: toolchain is already up to date
 fn rustup_all_channels() {
     setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup-setup", "-y"]);
+        expect_ok(config, &["rustup", "update", "stable"]);
         expect_ok(config, &["multirust", "update", "beta"]);
         expect_ok(config, &["multirust", "update", "nightly"]);
         set_current_dist_date(config, "2015-01-02");
-        expect_ok_ex(config, &["rustup"],
+        expect_ok_ex(config, &["rustup", "--no-self-update"],
 r"
 stable updated:
 
@@ -132,12 +132,12 @@ info: toolchain 'nightly' installed
 fn rustup_some_channels_up_to_date() {
     setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup-setup", "-y"]);
+        expect_ok(config, &["rustup", "update", "stable"]);
         expect_ok(config, &["multirust", "update", "beta"]);
         expect_ok(config, &["multirust", "update", "nightly"]);
         set_current_dist_date(config, "2015-01-02");
         expect_ok(config, &["multirust", "update", "beta"]);
-        expect_ok_ex(config, &["rustup"],
+        expect_ok_ex(config, &["rustup", "--no-self-update"],
 r"
 stable updated:
 
@@ -187,9 +187,9 @@ info: toolchain 'nightly' installed
 #[test]
 fn rustup_no_channels() {
     setup(&|config| {
-        expect_ok(config, &["rustup-setup", "-y"]);
+        expect_ok(config, &["rustup", "update", "stable"]);
         expect_ok(config, &["multirust", "remove-toolchain", "stable"]);
-        expect_ok_ex(config, &["rustup"],
+        expect_ok_ex(config, &["rustup", "--no-self-update"],
 r"",
 r"info: no updatable toolchains installed
 ");

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -231,7 +231,7 @@ fn add_target() {
         expect_ok(config, &["rustup", "default", "nightly"]);
         expect_ok(config, &["rustup", "target", "add",
                             clitools::CROSS_ARCH1]);
-        assert!(config.rustupdir.path().join(path).exists());
+        assert!(config.rustupdir.join(path).exists());
     });
 }
 
@@ -243,10 +243,10 @@ fn remove_target() {
         expect_ok(config, &["rustup", "default", "nightly"]);
         expect_ok(config, &["rustup", "target", "add",
                             clitools::CROSS_ARCH1]);
-        assert!(config.rustupdir.path().join(path).exists());
+        assert!(config.rustupdir.join(path).exists());
         expect_ok(config, &["rustup", "target", "remove",
                             clitools::CROSS_ARCH1]);
-        assert!(!config.rustupdir.path().join(path).exists());
+        assert!(!config.rustupdir.join(path).exists());
     });
 }
 
@@ -262,7 +262,7 @@ fn list_targets() {
 #[test]
 fn link() {
     setup(&|config| {
-        let path = config.customdir.path().join("custom-1");
+        let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
         expect_ok(config, &["rustup", "toolchain", "link", "custom",
                             &path]);

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -231,7 +231,7 @@ fn add_target() {
         expect_ok(config, &["rustup", "default", "nightly"]);
         expect_ok(config, &["rustup", "target", "add",
                             clitools::CROSS_ARCH1]);
-        assert!(config.homedir.path().join(path).exists());
+        assert!(config.rustupdir.path().join(path).exists());
     });
 }
 
@@ -243,10 +243,10 @@ fn remove_target() {
         expect_ok(config, &["rustup", "default", "nightly"]);
         expect_ok(config, &["rustup", "target", "add",
                             clitools::CROSS_ARCH1]);
-        assert!(config.homedir.path().join(path).exists());
+        assert!(config.rustupdir.path().join(path).exists());
         expect_ok(config, &["rustup", "target", "remove",
                             clitools::CROSS_ARCH1]);
-        assert!(!config.homedir.path().join(path).exists());
+        assert!(!config.rustupdir.path().join(path).exists());
     });
 }
 

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -24,14 +24,10 @@ fn rustup_stable() {
         set_current_dist_date(config, "2015-01-02");
         expect_ok_ex(config, &["rustup", "--no-self-update"],
 r"
-stable updated:
-
-1.1.0 (hash-s-2)
-1.1.0 (hash-s-2)
+  stable updated: 1.1.0 (hash-s-2)
 
 ",
-r"info: updating existing install for 'stable'
-info: downloading toolchain manifest
+r"info: syncing channel updates for 'stable'
 info: downloading component 'rust-std'
 info: downloading component 'rustc'
 info: downloading component 'cargo'
@@ -40,7 +36,6 @@ info: installing component 'rust-std'
 info: installing component 'rustc'
 info: installing component 'cargo'
 info: installing component 'rust-docs'
-info: toolchain 'stable' installed
 ");
     });
 }
@@ -52,15 +47,10 @@ fn rustup_stable_no_change() {
         expect_ok(config, &["rustup", "update", "stable"]);
         expect_ok_ex(config, &["rustup", "--no-self-update"],
 r"
-stable unchanged:
-
-1.0.0 (hash-s-1)
-1.0.0 (hash-s-1)
+  stable unchanged: 1.0.0 (hash-s-1)
 
 ",
-r"info: updating existing install for 'stable'
-info: downloading toolchain manifest
-info: toolchain is already up to date
+r"info: syncing channel updates for 'stable'
 ");
     });
 }
@@ -75,24 +65,12 @@ fn rustup_all_channels() {
         set_current_dist_date(config, "2015-01-02");
         expect_ok_ex(config, &["rustup", "--no-self-update"],
 r"
-stable updated:
-
-1.1.0 (hash-s-2)
-1.1.0 (hash-s-2)
-
-beta updated:
-
-1.2.0 (hash-b-2)
-1.2.0 (hash-b-2)
-
-nightly updated:
-
-1.3.0 (hash-n-2)
-1.3.0 (hash-n-2)
+   stable updated: 1.1.0 (hash-s-2)
+     beta updated: 1.2.0 (hash-b-2)
+  nightly updated: 1.3.0 (hash-n-2)
 
 ",
-r"info: updating existing install for 'stable'
-info: downloading toolchain manifest
+r"info: syncing channel updates for 'stable'
 info: downloading component 'rust-std'
 info: downloading component 'rustc'
 info: downloading component 'cargo'
@@ -101,9 +79,7 @@ info: installing component 'rust-std'
 info: installing component 'rustc'
 info: installing component 'cargo'
 info: installing component 'rust-docs'
-info: toolchain 'stable' installed
-info: updating existing install for 'beta'
-info: downloading toolchain manifest
+info: syncing channel updates for 'beta'
 info: downloading component 'rust-std'
 info: downloading component 'rustc'
 info: downloading component 'cargo'
@@ -112,9 +88,7 @@ info: installing component 'rust-std'
 info: installing component 'rustc'
 info: installing component 'cargo'
 info: installing component 'rust-docs'
-info: toolchain 'beta' installed
-info: updating existing install for 'nightly'
-info: downloading toolchain manifest
+info: syncing channel updates for 'nightly'
 info: downloading component 'rust-std'
 info: downloading component 'rustc'
 info: downloading component 'cargo'
@@ -123,7 +97,6 @@ info: installing component 'rust-std'
 info: installing component 'rustc'
 info: installing component 'cargo'
 info: installing component 'rust-docs'
-info: toolchain 'nightly' installed
 ");
     })
 }
@@ -139,24 +112,12 @@ fn rustup_some_channels_up_to_date() {
         expect_ok(config, &["multirust", "update", "beta"]);
         expect_ok_ex(config, &["rustup", "--no-self-update"],
 r"
-stable updated:
-
-1.1.0 (hash-s-2)
-1.1.0 (hash-s-2)
-
-beta unchanged:
-
-1.2.0 (hash-b-2)
-1.2.0 (hash-b-2)
-
-nightly updated:
-
-1.3.0 (hash-n-2)
-1.3.0 (hash-n-2)
+   stable updated: 1.1.0 (hash-s-2)
+   beta unchanged: 1.2.0 (hash-b-2)
+  nightly updated: 1.3.0 (hash-n-2)
 
 ",
-r"info: updating existing install for 'stable'
-info: downloading toolchain manifest
+r"info: syncing channel updates for 'stable'
 info: downloading component 'rust-std'
 info: downloading component 'rustc'
 info: downloading component 'cargo'
@@ -165,12 +126,8 @@ info: installing component 'rust-std'
 info: installing component 'rustc'
 info: installing component 'cargo'
 info: installing component 'rust-docs'
-info: toolchain 'stable' installed
-info: updating existing install for 'beta'
-info: downloading toolchain manifest
-info: toolchain is already up to date
-info: updating existing install for 'nightly'
-info: downloading toolchain manifest
+info: syncing channel updates for 'beta'
+info: syncing channel updates for 'nightly'
 info: downloading component 'rust-std'
 info: downloading component 'rustc'
 info: downloading component 'cargo'
@@ -179,7 +136,6 @@ info: installing component 'rust-std'
 info: installing component 'rustc'
 info: installing component 'cargo'
 info: installing component 'rust-docs'
-info: toolchain 'nightly' installed
 ");
     })
 }
@@ -201,14 +157,10 @@ fn default() {
     setup(&|config| {
         expect_ok_ex(config, &["rustup", "default", "nightly"],
 r"
-nightly revision:
-
-1.3.0 (hash-n-2)
-1.3.0 (hash-n-2)
+  nightly installed: 1.3.0 (hash-n-2)
 
 ",
-r"info: installing toolchain 'nightly'
-info: downloading toolchain manifest
+r"info: syncing channel updates for 'nightly'
 info: downloading component 'rust-std'
 info: downloading component 'rustc'
 info: downloading component 'cargo'
@@ -217,7 +169,6 @@ info: installing component 'rust-std'
 info: installing component 'rustc'
 info: installing component 'cargo'
 info: installing component 'rust-docs'
-info: toolchain 'nightly' installed
 info: default toolchain set to 'nightly'
 ");
     });

--- a/tests/cli-self-update.rs
+++ b/tests/cli-self-update.rs
@@ -691,15 +691,10 @@ fn rustup_self_update_exact() {
 
         expect_ok_ex(config, &["rustup"],
 r"
-stable unchanged:
-
-1.1.0 (hash-s-2)
-1.1.0 (hash-s-2)
+  stable unchanged: 1.1.0 (hash-s-2)
 
 ",
-r"info: updating existing install for 'stable'
-info: downloading toolchain manifest
-info: toolchain is already up to date
+r"info: syncing channel updates for 'stable'
 info: checking for self-updates
 info: downloading self-update
 ");
@@ -728,18 +723,7 @@ fn updater_is_deleted_after_running_multirust() {
         expect_ok(config, &["multirust", "update", "nightly"]);
         expect_ok(config, &["multirust", "self", "update"]);
 
-        expect_ok_ex(config, &["multirust", "update", "nightly"],
-r"
-nightly revision:
-
-1.3.0 (hash-n-2)
-1.3.0 (hash-n-2)
-
-",
-r"info: updating existing install for 'nightly'
-info: downloading toolchain manifest
-info: toolchain is already up to date
-");
+        expect_ok(config, &["multirust", "update", "nightly"]);
 
         let setup = config.cargodir.join(&format!("bin/multirust-setup{}", EXE_SUFFIX));
         assert!(!setup.exists());
@@ -785,14 +769,10 @@ fn first_install_exact() {
     setup(&|config| {
         expect_ok_ex(config, &["multirust-setup", "-y"],
 r"
-stable revision:
-
-1.1.0 (hash-s-2)
-1.1.0 (hash-s-2)
+  stable installed: 1.1.0 (hash-s-2)
 
 ",
-r"info: installing toolchain 'stable'
-info: downloading toolchain manifest
+r"info: syncing channel updates for 'stable'
 info: downloading component 'rust-std'
 info: downloading component 'rustc'
 info: downloading component 'cargo'
@@ -801,7 +781,6 @@ info: installing component 'rust-std'
 info: installing component 'rustc'
 info: installing component 'cargo'
 info: installing component 'rust-docs'
-info: toolchain 'stable' installed
 info: default toolchain set to 'stable'
 "
                   );

--- a/tests/cli-self-update.rs
+++ b/tests/cli-self-update.rs
@@ -28,7 +28,7 @@ use multirust_mock::clitools::{self, Config, Scenario,
 use multirust_mock::dist::{create_hash, calc_hash};
 use multirust_utils::raw;
 
-pub fn setup(f: &Fn(&Config, &Path, &Path)) {
+pub fn setup(f: &Fn(&Config)) {
     clitools::setup(Scenario::SimpleV2, &|config| {
         // Lock protects environment variables
         lazy_static! {
@@ -36,30 +36,17 @@ pub fn setup(f: &Fn(&Config, &Path, &Path)) {
         }
         let _g = LOCK.lock();
 
-        let cargo_home_tmp = TempDir::new("cargo_home").unwrap();
-        // The uninstall process on windows involves using the directory above
-        // CARGO_HOME, so make sure it's a subdir of our tempdir
-        let ref cargo_home = cargo_home_tmp.path().join("ch");
-        fs::create_dir(cargo_home).unwrap();
-
-        let home_tmp = TempDir::new("home").unwrap();
-        let home = home_tmp.path();
-
-        // Both of these are only read during install/uninstall
-        env::set_var("CARGO_HOME", &*cargo_home.to_string_lossy());
-        env::set_var("HOME", &*home.to_string_lossy());
-
         // An windows these tests mess with the user's PATH. Save
         // and restore them here to keep from trashing things.
         let ref saved_path = get_path();
         defer! { restore_path(saved_path) }
 
-        f(config, cargo_home, home);
+        f(config);
     });
 }
 
-pub fn update_setup(f: &Fn(&Config, &Path, &Path)) {
-    setup(&|config, cargo_home, _| {
+pub fn update_setup(f: &Fn(&Config, &Path)) {
+    setup(&|config| {
 
         // Create a mock self-update server
         let ref self_dist_tmp = TempDir::new("self_dist").unwrap();
@@ -80,20 +67,20 @@ pub fn update_setup(f: &Fn(&Config, &Path, &Path)) {
         let ref root_url = format!("file://{}", self_dist.display());
         env::set_var("MULTIRUST_UPDATE_ROOT", root_url);
 
-        f(config, cargo_home, self_dist);
+        f(config, self_dist);
     });
 }
 
 #[test]
 fn install_bins_to_cargo_home() {
-    setup(&|config, cargo_home, _| {
+    setup(&|config| {
         expect_ok(config, &["multirust-setup", "-y"]);
-        let multirust = cargo_home.join(&format!("bin/multirust{}", EXE_SUFFIX));
-        let rustc = cargo_home.join(&format!("bin/rustc{}", EXE_SUFFIX));
-        let rustdoc = cargo_home.join(&format!("bin/rustdoc{}", EXE_SUFFIX));
-        let cargo = cargo_home.join(&format!("bin/cargo{}", EXE_SUFFIX));
-        let rust_lldb = cargo_home.join(&format!("bin/rust-lldb{}", EXE_SUFFIX));
-        let rust_gdb = cargo_home.join(&format!("bin/rust-gdb{}", EXE_SUFFIX));
+        let multirust = config.cargodir.join(&format!("bin/multirust{}", EXE_SUFFIX));
+        let rustc = config.cargodir.join(&format!("bin/rustc{}", EXE_SUFFIX));
+        let rustdoc = config.cargodir.join(&format!("bin/rustdoc{}", EXE_SUFFIX));
+        let cargo = config.cargodir.join(&format!("bin/cargo{}", EXE_SUFFIX));
+        let rust_lldb = config.cargodir.join(&format!("bin/rust-lldb{}", EXE_SUFFIX));
+        let rust_gdb = config.cargodir.join(&format!("bin/rust-gdb{}", EXE_SUFFIX));
         assert!(multirust.exists());
         assert!(rustc.exists());
         assert!(rustdoc.exists());
@@ -105,10 +92,10 @@ fn install_bins_to_cargo_home() {
 
 #[test]
 fn install_twice() {
-    setup(&|config, cargo_home, _| {
+    setup(&|config| {
         expect_ok(config, &["multirust-setup", "-y"]);
         expect_ok(config, &["multirust-setup", "-y"]);
-        let multirust = cargo_home.join(&format!("bin/multirust{}", EXE_SUFFIX));
+        let multirust = config.cargodir.join(&format!("bin/multirust{}", EXE_SUFFIX));
         assert!(multirust.exists());
     });
 }
@@ -116,14 +103,14 @@ fn install_twice() {
 #[test]
 #[cfg(unix)]
 fn bins_are_executable() {
-    setup(&|config, cargo_home, _| {
+    setup(&|config| {
         expect_ok(config, &["multirust-setup", "-y"]);
-        let ref multirust = cargo_home.join(&format!("bin/multirust{}", EXE_SUFFIX));
-        let ref rustc = cargo_home.join(&format!("bin/rustc{}", EXE_SUFFIX));
-        let ref rustdoc = cargo_home.join(&format!("bin/rustdoc{}", EXE_SUFFIX));
-        let ref cargo = cargo_home.join(&format!("bin/cargo{}", EXE_SUFFIX));
-        let ref rust_lldb = cargo_home.join(&format!("bin/rust-lldb{}", EXE_SUFFIX));
-        let ref rust_gdb = cargo_home.join(&format!("bin/rust-gdb{}", EXE_SUFFIX));
+        let ref multirust = config.cargodir.join(&format!("bin/multirust{}", EXE_SUFFIX));
+        let ref rustc = config.cargodir.join(&format!("bin/rustc{}", EXE_SUFFIX));
+        let ref rustdoc = config.cargodir.join(&format!("bin/rustdoc{}", EXE_SUFFIX));
+        let ref cargo = config.cargodir.join(&format!("bin/cargo{}", EXE_SUFFIX));
+        let ref rust_lldb = config.cargodir.join(&format!("bin/rust-lldb{}", EXE_SUFFIX));
+        let ref rust_gdb = config.cargodir.join(&format!("bin/rust-gdb{}", EXE_SUFFIX));
         assert!(is_exe(multirust));
         assert!(is_exe(rustc));
         assert!(is_exe(rustdoc));
@@ -142,25 +129,25 @@ fn bins_are_executable() {
 
 #[test]
 fn install_creates_cargo_home() {
-    setup(&|config, cargo_home, _| {
-        fs::remove_dir(cargo_home).unwrap();
+    setup(&|config| {
+        fs::remove_dir(&config.cargodir).unwrap();
         fs::remove_dir(&config.rustupdir).unwrap();
         expect_ok(config, &["multirust-setup", "-y"]);
-        assert!(cargo_home.exists());
+        assert!(config.cargodir.exists());
     });
 }
 
 #[test]
 fn uninstall_deletes_bins() {
-    setup(&|config, cargo_home, _| {
+    setup(&|config| {
         expect_ok(config, &["multirust-setup", "-y"]);
         expect_ok(config, &["multirust", "self", "uninstall", "-y"]);
-        let multirust = cargo_home.join(&format!("bin/multirust{}", EXE_SUFFIX));
-        let rustc = cargo_home.join(&format!("bin/rustc{}", EXE_SUFFIX));
-        let rustdoc = cargo_home.join(&format!("bin/rustdoc{}", EXE_SUFFIX));
-        let cargo = cargo_home.join(&format!("bin/cargo{}", EXE_SUFFIX));
-        let rust_lldb = cargo_home.join(&format!("bin/rust-lldb{}", EXE_SUFFIX));
-        let rust_gdb = cargo_home.join(&format!("bin/rust-gdb{}", EXE_SUFFIX));
+        let multirust = config.cargodir.join(&format!("bin/multirust{}", EXE_SUFFIX));
+        let rustc = config.cargodir.join(&format!("bin/rustc{}", EXE_SUFFIX));
+        let rustdoc = config.cargodir.join(&format!("bin/rustdoc{}", EXE_SUFFIX));
+        let cargo = config.cargodir.join(&format!("bin/cargo{}", EXE_SUFFIX));
+        let rust_lldb = config.cargodir.join(&format!("bin/rust-lldb{}", EXE_SUFFIX));
+        let rust_gdb = config.cargodir.join(&format!("bin/rust-gdb{}", EXE_SUFFIX));
         assert!(!multirust.exists());
         assert!(!rustc.exists());
         assert!(!rustdoc.exists());
@@ -172,14 +159,14 @@ fn uninstall_deletes_bins() {
 
 #[test]
 fn uninstall_works_if_some_bins_dont_exist() {
-    setup(&|config, cargo_home, _| {
+    setup(&|config| {
         expect_ok(config, &["multirust-setup", "-y"]);
-        let multirust = cargo_home.join(&format!("bin/multirust{}", EXE_SUFFIX));
-        let rustc = cargo_home.join(&format!("bin/rustc{}", EXE_SUFFIX));
-        let rustdoc = cargo_home.join(&format!("bin/rustdoc{}", EXE_SUFFIX));
-        let cargo = cargo_home.join(&format!("bin/cargo{}", EXE_SUFFIX));
-        let rust_lldb = cargo_home.join(&format!("bin/rust-lldb{}", EXE_SUFFIX));
-        let rust_gdb = cargo_home.join(&format!("bin/rust-gdb{}", EXE_SUFFIX));
+        let multirust = config.cargodir.join(&format!("bin/multirust{}", EXE_SUFFIX));
+        let rustc = config.cargodir.join(&format!("bin/rustc{}", EXE_SUFFIX));
+        let rustdoc = config.cargodir.join(&format!("bin/rustdoc{}", EXE_SUFFIX));
+        let cargo = config.cargodir.join(&format!("bin/cargo{}", EXE_SUFFIX));
+        let rust_lldb = config.cargodir.join(&format!("bin/rust-lldb{}", EXE_SUFFIX));
+        let rust_gdb = config.cargodir.join(&format!("bin/rust-gdb{}", EXE_SUFFIX));
 
         fs::remove_file(&rustc).unwrap();
         fs::remove_file(&cargo).unwrap();
@@ -197,7 +184,7 @@ fn uninstall_works_if_some_bins_dont_exist() {
 
 #[test]
 fn uninstall_deletes_multirust_home() {
-    setup(&|config, _, _| {
+    setup(&|config| {
         expect_ok(config, &["multirust-setup", "-y"]);
         expect_ok(config, &["multirust", "default", "nightly"]);
         expect_ok(config, &["multirust", "self", "uninstall", "-y"]);
@@ -207,7 +194,7 @@ fn uninstall_deletes_multirust_home() {
 
 #[test]
 fn uninstall_works_if_multirust_home_doesnt_exist() {
-    setup(&|config, _, _| {
+    setup(&|config| {
         expect_ok(config, &["multirust-setup", "-y"]);
         fs::remove_dir_all(&config.rustupdir).unwrap();
         expect_ok(config, &["multirust", "self", "uninstall", "-y"]);
@@ -216,18 +203,18 @@ fn uninstall_works_if_multirust_home_doesnt_exist() {
 
 #[test]
 fn uninstall_deletes_cargo_home() {
-    setup(&|config, cargo_home, _| {
+    setup(&|config| {
         expect_ok(config, &["multirust-setup", "-y"]);
         expect_ok(config, &["multirust", "self", "uninstall", "-y"]);
-        assert!(!cargo_home.exists());
+        assert!(!config.cargodir.exists());
     });
 }
 
 #[test]
 fn uninstall_fails_if_not_installed() {
-    setup(&|config, cargo_home, _| {
+    setup(&|config| {
         expect_ok(config, &["multirust-setup", "-y"]);
-        let multirust = cargo_home.join(&format!("bin/multirust{}", EXE_SUFFIX));
+        let multirust = config.cargodir.join(&format!("bin/multirust{}", EXE_SUFFIX));
         fs::remove_file(&multirust).unwrap();
         expect_err(config, &["multirust", "self", "uninstall", "-y"],
                    "multirust is not installed");
@@ -239,9 +226,9 @@ fn uninstall_fails_if_not_installed() {
 // order to test that it can successfully delete itself.
 #[test]
 fn uninstall_self_delete_works() {
-    setup(&|config, cargo_home, _| {
+    setup(&|config| {
         expect_ok(config, &["multirust-setup", "-y"]);
-        let multirust = cargo_home.join(&format!("bin/multirust{}", EXE_SUFFIX));
+        let multirust = config.cargodir.join(&format!("bin/multirust{}", EXE_SUFFIX));
         let mut cmd = Command::new(multirust.clone());
         cmd.args(&["self", "uninstall", "-y"]);
         clitools::env(config, &mut cmd);
@@ -251,13 +238,13 @@ fn uninstall_self_delete_works() {
 
         assert!(out.status.success());
         assert!(!multirust.exists());
-        assert!(!cargo_home.exists());
+        assert!(!config.cargodir.exists());
 
-        let rustc = cargo_home.join(&format!("bin/rustc{}", EXE_SUFFIX));
-        let rustdoc = cargo_home.join(&format!("bin/rustdoc{}", EXE_SUFFIX));
-        let cargo = cargo_home.join(&format!("bin/cargo{}", EXE_SUFFIX));
-        let rust_lldb = cargo_home.join(&format!("bin/rust-lldb{}", EXE_SUFFIX));
-        let rust_gdb = cargo_home.join(&format!("bin/rust-gdb{}", EXE_SUFFIX));
+        let rustc = config.cargodir.join(&format!("bin/rustc{}", EXE_SUFFIX));
+        let rustdoc = config.cargodir.join(&format!("bin/rustdoc{}", EXE_SUFFIX));
+        let cargo = config.cargodir.join(&format!("bin/cargo{}", EXE_SUFFIX));
+        let rust_lldb = config.cargodir.join(&format!("bin/rust-lldb{}", EXE_SUFFIX));
+        let rust_gdb = config.cargodir.join(&format!("bin/rust-gdb{}", EXE_SUFFIX));
         assert!(!rustc.exists());
         assert!(!rustdoc.exists());
         assert!(!cargo.exists());
@@ -267,14 +254,14 @@ fn uninstall_self_delete_works() {
 }
 
 // On windows multirust self uninstall temporarily puts a multirust-gc-$randomnumber.exe
-// file in CARGO_HOME/.. ; check that it doesn't exist.
+// file in CONFIG.CARGODIR/.. ; check that it doesn't exist.
 #[test]
 fn uninstall_doesnt_leave_gc_file() {
-    setup(&|config, cargo_home, _| {
+    setup(&|config| {
         expect_ok(config, &["multirust-setup", "-y"]);
         expect_ok(config, &["multirust", "self", "uninstall", "-y"]);
 
-        let ref parent = cargo_home.parent().unwrap();
+        let ref parent = config.cargodir.parent().unwrap();
         // Actually, there just shouldn't be any files here
         for dirent in fs::read_dir(parent).unwrap() {
             let dirent = dirent.unwrap();
@@ -291,15 +278,15 @@ fn uninstall_stress_test() {
 
 #[cfg(unix)]
 fn install_adds_path_to_rc(rcfile: &str) {
-    setup(&|config, cargo_home, home| {
+    setup(&|config| {
         let my_rc = "foo\nbar\nbaz";
-        let ref rc = home.join(rcfile);
+        let ref rc = config.homedir.join(rcfile);
         raw::write_file(rc, my_rc).unwrap();
         expect_ok(config, &["multirust-setup", "-y"]);
 
         let new_rc = raw::read_file(rc).unwrap();
         let addition = format!(r#"export PATH="{}/bin:$PATH""#,
-                               cargo_home.display());
+                               config.cargodir.display());
         let expected = format!("{}\n{}\n", my_rc, addition);
         assert_eq!(new_rc, expected);
     });
@@ -326,14 +313,14 @@ fn install_adds_path_to_kshrc() {
 #[test]
 #[cfg(unix)]
 fn install_does_not_add_paths_to_rcfiles_that_dont_exist() {
-    setup(&|config, _, home| {
+    setup(&|config| {
         let my_bashrc = "foo\nbar\nbaz";
-        let ref bashrc = home.join(".bashrc");
+        let ref bashrc = config.homedir.join(".bashrc");
         raw::write_file(bashrc, my_bashrc).unwrap();
         expect_ok(config, &["multirust-setup", "-y"]);
 
-        let ref zshrc = home.join(".zshrc");
-        let ref kshrc = home.join(".kshrc");
+        let ref zshrc = config.homedir.join(".zshrc");
+        let ref kshrc = config.homedir.join(".kshrc");
         assert!(!zshrc.exists());
         assert!(!kshrc.exists());
     });
@@ -347,16 +334,16 @@ fn install_adds_path_to_bashrc_zshrc_and_kshrc() {
 #[test]
 #[cfg(unix)]
 fn install_adds_path_to_rcfile_just_once() {
-    setup(&|config, cargo_home, home| {
+    setup(&|config| {
         let my_bashrc = "foo\nbar\nbaz";
-        let ref bashrc = home.join(".bashrc");
+        let ref bashrc = config.homedir.join(".bashrc");
         raw::write_file(bashrc, my_bashrc).unwrap();
         expect_ok(config, &["multirust-setup", "-y"]);
         expect_ok(config, &["multirust-setup", "-y"]);
 
         let new_bashrc = raw::read_file(bashrc).unwrap();
         let addition = format!(r#"export PATH="{}/bin:$PATH""#,
-                               cargo_home.display());
+                               config.cargodir.display());
         let expected = format!("{}\n{}\n", my_bashrc, addition);
         assert_eq!(new_bashrc, expected);
     });
@@ -366,20 +353,20 @@ fn install_adds_path_to_rcfile_just_once() {
 #[test]
 #[cfg(unix)]
 fn install_when_no_path_methods() {
-    setup(&|config, _, home| {
+    setup(&|config| {
         expect_ok(config, &["multirust-setup", "-y"]);
 
         for rc in &[".bashrc", ".zshrc", ".kshrc"] {
-            assert!(!home.join(rc).exists());
+            assert!(!config.homedir.join(rc).exists());
         }
     });
 }
 
 #[cfg(unix)]
 fn uninstall_removes_path_from_rc(rcfile: &str) {
-    setup(&|config, _, home| {
+    setup(&|config| {
         let my_rc = "foo\nbar\nbaz";
-        let ref rc = home.join(rcfile);
+        let ref rc = config.homedir.join(rcfile);
         raw::write_file(rc, my_rc).unwrap();
         expect_ok(config, &["multirust-setup", "-y"]);
         expect_ok(config, &["multirust", "self", "uninstall", "-y"]);
@@ -410,15 +397,15 @@ fn uninstall_removes_path_from_kshrc() {
 #[test]
 #[cfg(unix)]
 fn uninstall_doesnt_touch_rc_files_that_dont_exist() {
-    setup(&|config, _, home| {
+    setup(&|config| {
         let my_rc = "foo\nbar\nbaz";
-        let ref bashrc = home.join(".bashrc");
+        let ref bashrc = config.homedir.join(".bashrc");
         raw::write_file(bashrc, my_rc).unwrap();
         expect_ok(config, &["multirust-setup", "-y"]);
         expect_ok(config, &["multirust", "self", "uninstall", "-y"]);
 
-        let ref zshrc = home.join(".zshrc");
-        let ref kshrc = home.join(".zshrc");
+        let ref zshrc = config.homedir.join(".zshrc");
+        let ref kshrc = config.homedir.join(".zshrc");
         assert!(!zshrc.exists());
         assert!(!kshrc.exists());
     });
@@ -426,14 +413,14 @@ fn uninstall_doesnt_touch_rc_files_that_dont_exist() {
 
 #[test]
 #[cfg(unix)]
-fn uninstall_doesnt_touch_rc_files_that_dont_contain_cargo_home_path() {
-    setup(&|config, _, home| {
+fn uninstall_doesnt_touch_rc_files_that_dont_contain_cargo_home() {
+    setup(&|config| {
         let my_rc = "foo\nbar\nbaz";
-        let ref bashrc = home.join(".bashrc");
+        let ref bashrc = config.homedir.join(".bashrc");
         raw::write_file(bashrc, my_rc).unwrap();
         expect_ok(config, &["multirust-setup", "-y"]);
 
-        let ref zshrc = home.join(".zshrc");
+        let ref zshrc = config.homedir.join(".zshrc");
         raw::write_file(zshrc, my_rc).unwrap();
 
         let zsh = raw::read_file(zshrc).unwrap();
@@ -449,23 +436,26 @@ fn uninstall_doesnt_touch_rc_files_that_dont_contain_cargo_home_path() {
 #[test]
 #[cfg(unix)]
 fn when_cargo_home_is_the_default_write_path_specially() {
-    setup(&|config, _, home| {
-        // Override the test harness so that cargo home looks
-        // like $HOME/.cargo, otherwise the literal path will
-        // be written to the file
-        env::remove_var("CARGO_HOME");
+    setup(&|config| {
+        // Override the test harness so that cargo home looks like
+        // $HOME/.cargo by removing CARGO_HOME from the environment,
+        // otherwise the literal path will be written to the file.
 
         let my_bashrc = "foo\nbar\nbaz";
-        let ref bashrc = home.join(".bashrc");
+        let ref bashrc = config.homedir.join(".bashrc");
         raw::write_file(bashrc, my_bashrc).unwrap();
-        expect_ok(config, &["multirust-setup", "-y"]);
+        let mut cmd = clitools::cmd(config, "multirust-setup", &["-y"]);
+        cmd.env_remove("CARGO_HOME");
+        assert!(cmd.output().unwrap().status.success());
 
         let new_bashrc = raw::read_file(bashrc).unwrap();
         let addition = format!(r#"export PATH="$HOME/.cargo/bin:$PATH""#);
         let expected = format!("{}\n{}\n", my_bashrc, addition);
         assert_eq!(new_bashrc, expected);
 
-        expect_ok(config, &["multirust", "self", "uninstall", "-y"]);
+        let mut cmd = clitools::cmd(config, "multirust", &["self", "uninstall", "-y"]);
+        cmd.env_remove("CARGO_HOME");
+        assert!(cmd.output().unwrap().status.success());
 
         let new_bashrc = raw::read_file(bashrc).unwrap();
         assert_eq!(new_bashrc, my_bashrc);
@@ -503,10 +493,10 @@ fn restore_path(_: &str) { }
 #[test]
 #[cfg(windows)]
 fn install_adds_path() {
-    setup(&|config, cargo_home, _| {
+    setup(&|config| {
         expect_ok(config, &["multirust-setup", "-y"]);
 
-        let path = cargo_home.join("bin").to_string_lossy().to_string();
+        let path = config.cargodir.join("bin").to_string_lossy().to_string();
         assert!(get_path().contains(&path));
     });
 }
@@ -514,11 +504,11 @@ fn install_adds_path() {
 #[test]
 #[cfg(windows)]
 fn install_does_not_add_path_twice() {
-    setup(&|config, cargo_home, _| {
+    setup(&|config| {
         expect_ok(config, &["multirust-setup", "-y"]);
         expect_ok(config, &["multirust-setup", "-y"]);
 
-        let path = cargo_home.join("bin").to_string_lossy().to_string();
+        let path = config.cargodir.join("bin").to_string_lossy().to_string();
         assert_eq!(get_path().matches(&path).count(), 1);
     });
 }
@@ -526,18 +516,18 @@ fn install_does_not_add_path_twice() {
 #[test]
 #[cfg(windows)]
 fn uninstall_removes_path() {
-    setup(&|config, cargo_home, _| {
+    setup(&|config| {
         expect_ok(config, &["multirust-setup", "-y"]);
         expect_ok(config, &["multirust", "self", "uninstall", "-y"]);
 
-        let path = cargo_home.join("bin").to_string_lossy().to_string();
+        let path = config.cargodir.join("bin").to_string_lossy().to_string();
         assert!(!get_path().contains(&path));
     });
 }
 
 #[test]
 fn update_exact() {
-    update_setup(&|config, _, _| {
+    update_setup(&|config, _| {
         expect_ok(config, &["multirust-setup", "-y"]);
         expect_ok_ex(config, &["multirust", "self", "update"],
 r"",
@@ -550,20 +540,20 @@ info: multirust updated successfully
 
 #[test]
 fn update_but_not_installed() {
-    update_setup(&|config, cargo_home, _| {
+    update_setup(&|config, _| {
         expect_err_ex(config, &["multirust", "self", "update"],
 r"",
 &format!(
 r"error: multirust is not installed at '{}'
-", cargo_home.display()));
+", config.cargodir.display()));
     });
 }
 
 #[test]
 fn update_but_delete_existing_updater_first() {
-    update_setup(&|config, cargo_home, _| {
+    update_setup(&|config, _| {
         // The updater is stored in a known location
-        let ref setup = cargo_home.join(&format!("bin/multirust-setup{}", EXE_SUFFIX));
+        let ref setup = config.cargodir.join(&format!("bin/multirust-setup{}", EXE_SUFFIX));
 
         expect_ok(config, &["multirust-setup", "-y"]);
 
@@ -572,14 +562,14 @@ fn update_but_delete_existing_updater_first() {
         raw::write_file(setup, "").unwrap();
         expect_ok(config, &["multirust", "self", "update"]);
 
-        let multirust = cargo_home.join(&format!("bin/multirust{}", EXE_SUFFIX));
+        let multirust = config.cargodir.join(&format!("bin/multirust{}", EXE_SUFFIX));
         assert!(multirust.exists());
     });
 }
 
 #[test]
 fn update_no_change() {
-    update_setup(&|config, _, self_dist| {
+    update_setup(&|config, self_dist| {
         expect_ok(config, &["multirust-setup", "-y"]);
 
         let ref trip = this_host_triple();
@@ -601,7 +591,7 @@ info: multirust is already up to date
 
 #[test]
 fn update_bad_hash() {
-    update_setup(&|config, _, self_dist| {
+    update_setup(&|config, self_dist| {
         expect_ok(config, &["multirust-setup", "-y"]);
 
         let ref trip = this_host_triple();
@@ -619,7 +609,7 @@ fn update_bad_hash() {
 
 #[test]
 fn update_hash_file_404() {
-    update_setup(&|config, _, self_dist| {
+    update_setup(&|config, self_dist| {
         expect_ok(config, &["multirust-setup", "-y"]);
 
         let ref trip = this_host_triple();
@@ -635,7 +625,7 @@ fn update_hash_file_404() {
 
 #[test]
 fn update_download_404() {
-    update_setup(&|config, _, self_dist| {
+    update_setup(&|config, self_dist| {
         expect_ok(config, &["multirust-setup", "-y"]);
 
         let ref trip = this_host_triple();
@@ -654,10 +644,10 @@ fn update_download_404() {
 // before the new updater can delete it.
 #[test]
 fn update_updates_multirust_bin() {
-    update_setup(&|config, cargo_home, _| {
+    update_setup(&|config, _| {
         expect_ok(config, &["multirust-setup", "-y"]);
 
-        let ref bin = cargo_home.join(&format!("bin/multirust{}", EXE_SUFFIX));
+        let ref bin = config.cargodir.join(&format!("bin/multirust{}", EXE_SUFFIX));
         let before_hash = calc_hash(bin);
 
         // Running the self update command on the installed binary,
@@ -683,19 +673,19 @@ fn update_updates_multirust_bin() {
 // invocations of multirust.
 #[test]
 fn updater_leaves_itself_for_later_deletion() {
-    update_setup(&|config, cargo_home, _| {
+    update_setup(&|config, _| {
         expect_ok(config, &["multirust-setup", "-y"]);
         expect_ok(config, &["multirust", "update", "nightly"]);
         expect_ok(config, &["multirust", "self", "update"]);
 
-        let setup = cargo_home.join(&format!("bin/multirust-setup{}", EXE_SUFFIX));
+        let setup = config.cargodir.join(&format!("bin/multirust-setup{}", EXE_SUFFIX));
         assert!(setup.exists());
     });
 }
 
 #[test]
 fn updater_is_deleted_after_running_multirust() {
-    update_setup(&|config, cargo_home, _| {
+    update_setup(&|config, _| {
         expect_ok(config, &["multirust-setup", "-y"]);
         expect_ok(config, &["multirust", "update", "nightly"]);
         expect_ok(config, &["multirust", "self", "update"]);
@@ -713,28 +703,28 @@ info: downloading toolchain manifest
 info: toolchain is already up to date
 ");
 
-        let setup = cargo_home.join(&format!("bin/multirust-setup{}", EXE_SUFFIX));
+        let setup = config.cargodir.join(&format!("bin/multirust-setup{}", EXE_SUFFIX));
         assert!(!setup.exists());
     });
 }
 
 #[test]
 fn updater_is_deleted_after_running_rustc() {
-    update_setup(&|config, cargo_home, _| {
+    update_setup(&|config, _| {
         expect_ok(config, &["multirust-setup", "-y"]);
         expect_ok(config, &["multirust", "default", "nightly"]);
         expect_ok(config, &["multirust", "self", "update"]);
 
         expect_ok(config, &["rustc", "--version"]);
 
-        let setup = cargo_home.join(&format!("bin/multirust-setup{}", EXE_SUFFIX));
+        let setup = config.cargodir.join(&format!("bin/multirust-setup{}", EXE_SUFFIX));
         assert!(!setup.exists());
     });
 }
 
 #[test]
 fn multirust_still_works_after_update() {
-    update_setup(&|config, _, _| {
+    update_setup(&|config, _| {
         expect_ok(config, &["multirust-setup", "-y"]);
         expect_ok(config, &["multirust", "default", "nightly"]);
         expect_ok(config, &["multirust", "self", "update"]);
@@ -754,7 +744,7 @@ fn update_stress_test() {
 
 #[test]
 fn first_install_exact() {
-    setup(&|config, _, _| {
+    setup(&|config| {
         expect_ok_ex(config, &["multirust-setup", "-y"],
 r"
 stable revision:
@@ -782,7 +772,7 @@ info: default toolchain set to 'stable'
 
 #[test]
 fn reinstall_exact() {
-    setup(&|config, _, _| {
+    setup(&|config| {
         expect_ok(config, &["multirust-setup", "-y"]);
         expect_ok_ex(config, &["multirust-setup", "-y"],
 r"",
@@ -795,14 +785,15 @@ r"info: updating existing installation
 #[test]
 #[cfg(unix)]
 fn produces_env_file_on_unix() {
-    setup(&|config, _, home| {
-        // Override the test harness so that cargo home looks
-        // like $HOME/.cargo, otherwise the literal path will
-        // be written to the file
-        env::remove_var("CARGO_HOME");
+    setup(&|config| {
+        // Override the test harness so that cargo home looks like
+        // $HOME/.cargo by removing CARGO_HOME from the environment,
+        // otherwise the literal path will be written to the file.
 
-        expect_ok(config, &["multirust-setup", "-y"]);
-        let ref envfile = home.join(".cargo/env");
+        let mut cmd = clitools::cmd(config, "multirust-setup", &["-y"]);
+        cmd.env_remove("CARGO_HOME");
+        assert!(cmd.output().unwrap().status.success());
+        let ref envfile = config.homedir.join(".cargo/env");
         let envfile = raw::read_file(envfile).unwrap();
         assert_eq!(r#"export PATH="$HOME/.cargo/bin:$PATH""#, envfile);
     });
@@ -815,7 +806,7 @@ fn doesnt_produce_env_file_on_windows() {
 
 #[test]
 fn install_sets_up_stable() {
-    setup(&|config, _, _| {
+    setup(&|config| {
         expect_ok(config, &["multirust-setup", "-y"]);
         expect_stdout_ok(config, &["rustc", "--version"],
                          "hash-s-2");
@@ -824,7 +815,7 @@ fn install_sets_up_stable() {
 
 #[test]
 fn install_sets_up_stable_unless_there_is_already_a_default() {
-    setup(&|config, _, _| {
+    setup(&|config| {
         expect_ok(config, &["multirust-setup", "-y"]);
         expect_ok(config, &["multirust", "default", "nightly"]);
         expect_ok(config, &["multirust", "remove-toolchain", "stable"]);
@@ -842,7 +833,7 @@ fn install_sets_up_stable_unless_there_is_already_a_default() {
 #[test]
 #[cfg(unix)]
 fn install_deletes_legacy_multirust_bins() {
-    setup(&|config, _, _| {
+    setup(&|config| {
         let ref multirust_bin_dir = config.rustupdir.join("bin");
         fs::create_dir_all(multirust_bin_dir).unwrap();
         let ref multirust_bin = multirust_bin_dir.join("multirust");
@@ -872,20 +863,22 @@ fn install_deletes_legacy_multirust_bins() {
     // windows::get_special_folder(&windows::FOLDERID_Profile).unwrap();
 }
 
-// multirust-setup obeys CARGO_HOME, which multirust-rs *used* to set
+// multirust-setup obeys CONFIG.CARGODIR, which multirust-rs *used* to set
 // before installation moved from ~/.multirust/bin to ~/.cargo/bin.
 // If installation running under the old multirust via `cargo run`,
-// then CARGO_HOME will be set during installation, causing the
+// then CONFIG.CARGODIR will be set during installation, causing the
 // install to go to the wrong place. Detect this scenario specifically
 // and avoid it.
 #[test]
 #[cfg(unix)] // Can't test on windows without clobbering the home dir
 fn legacy_upgrade_installs_to_correct_location() {
-    setup(&|config, _, home| {
+    setup(&|config| {
         let fake_cargo = config.rustupdir.join(".multirust/cargo");
-        env::set_var("CARGO_HOME", format!("{}", fake_cargo.display()));
-        expect_ok(config, &["multirust-setup", "-y"]);
-        let multirust = home.join(&format!(".cargo/bin/multirust{}", EXE_SUFFIX));
+        let mut cmd = clitools::cmd(config, "multirust-setup", &["-y"]);
+        cmd.env("CARGO_HOME", format!("{}", fake_cargo.display()));
+        assert!(cmd.output().unwrap().status.success());
+
+        let multirust = config.homedir.join(&format!(".cargo/bin/multirust{}", EXE_SUFFIX));
         assert!(multirust.exists());
     });
 }
@@ -894,7 +887,7 @@ fn legacy_upgrade_installs_to_correct_location() {
 
 #[test]
 fn readline_no_stdin() {
-    setup(&|config, _, _| {
+    setup(&|config| {
         expect_err(config, &["multirust-setup"],
                    "unable to read from stdin for confirmation");
     });
@@ -904,14 +897,14 @@ fn readline_no_stdin() {
 fn multirust_setup_works_with_weird_names() {
     // Browsers often rename bins to e.g. multirust-setup(2).exe.
 
-    setup(&|config, cargo_home, _| {
+    setup(&|config| {
         let ref old = config.exedir.join(
             &format!("multirust-setup{}", EXE_SUFFIX));
         let ref new = config.exedir.join(
             &format!("multirust-setup(2){}", EXE_SUFFIX));
         fs::rename(old, new).unwrap();
         expect_ok(config, &["multirust-setup(2)", "-y"]);
-        let multirust = cargo_home.join(&format!("bin/multirust{}", EXE_SUFFIX));
+        let multirust = config.cargodir.join(&format!("bin/multirust{}", EXE_SUFFIX));
         assert!(multirust.exists());
     });
 }

--- a/tests/cli-self-update.rs
+++ b/tests/cli-self-update.rs
@@ -69,8 +69,7 @@ pub fn update_setup(f: &Fn(&Config, &Path, &Path)) {
         let ref dist_dir = self_dist.join(&format!("{}", trip));
         let ref dist_exe = dist_dir.join(&format!("multirust-setup{}", EXE_SUFFIX));
         let ref dist_hash = dist_dir.join(&format!("multirust-setup{}.sha256", EXE_SUFFIX));
-        let ref multirust_bin = config.exedir
-            .path().join(&format!("multirust{}", EXE_SUFFIX));
+        let ref multirust_bin = config.exedir.join(&format!("multirust{}", EXE_SUFFIX));
 
         fs::create_dir_all(dist_dir).unwrap();
         fs::copy(multirust_bin, dist_exe).unwrap();
@@ -145,7 +144,7 @@ fn bins_are_executable() {
 fn install_creates_cargo_home() {
     setup(&|config, cargo_home, _| {
         fs::remove_dir(cargo_home).unwrap();
-        fs::remove_dir(config.rustupdir.path()).unwrap();
+        fs::remove_dir(&config.rustupdir).unwrap();
         expect_ok(config, &["multirust-setup", "-y"]);
         assert!(cargo_home.exists());
     });
@@ -202,7 +201,7 @@ fn uninstall_deletes_multirust_home() {
         expect_ok(config, &["multirust-setup", "-y"]);
         expect_ok(config, &["multirust", "default", "nightly"]);
         expect_ok(config, &["multirust", "self", "uninstall", "-y"]);
-        assert!(!config.rustupdir.path().exists());
+        assert!(!config.rustupdir.exists());
     });
 }
 
@@ -210,7 +209,7 @@ fn uninstall_deletes_multirust_home() {
 fn uninstall_works_if_multirust_home_doesnt_exist() {
     setup(&|config, _, _| {
         expect_ok(config, &["multirust-setup", "-y"]);
-        fs::remove_dir_all(&config.rustupdir.path()).unwrap();
+        fs::remove_dir_all(&config.rustupdir).unwrap();
         expect_ok(config, &["multirust", "self", "uninstall", "-y"]);
     });
 }
@@ -587,8 +586,7 @@ fn update_no_change() {
         let ref dist_dir = self_dist.join(&format!("{}", trip));
         let ref dist_exe = dist_dir.join(&format!("multirust-setup{}", EXE_SUFFIX));
         let ref dist_hash = dist_dir.join(&format!("multirust-setup{}.sha256", EXE_SUFFIX));
-        let ref multirust_bin = config.exedir
-            .path().join(&format!("multirust{}", EXE_SUFFIX));
+        let ref multirust_bin = config.exedir.join(&format!("multirust{}", EXE_SUFFIX));
         fs::copy(multirust_bin, dist_exe).unwrap();
         create_hash(dist_exe, dist_hash);
 
@@ -610,7 +608,7 @@ fn update_bad_hash() {
         let ref dist_dir = self_dist.join(&format!("{}", trip));
         let ref dist_hash = dist_dir.join(&format!("multirust-setup{}.sha256", EXE_SUFFIX));
 
-        let ref some_other_file = config.distdir.path().join("dist/channel-rust-nightly.toml");
+        let ref some_other_file = config.distdir.join("dist/channel-rust-nightly.toml");
 
         create_hash(some_other_file, dist_hash);
 
@@ -845,7 +843,7 @@ fn install_sets_up_stable_unless_there_is_already_a_default() {
 #[cfg(unix)]
 fn install_deletes_legacy_multirust_bins() {
     setup(&|config, _, _| {
-        let ref multirust_bin_dir = config.rustupdir.path().join("bin");
+        let ref multirust_bin_dir = config.rustupdir.join("bin");
         fs::create_dir_all(multirust_bin_dir).unwrap();
         let ref multirust_bin = multirust_bin_dir.join("multirust");
         let ref rustc_bin = multirust_bin_dir.join("rustc");
@@ -884,7 +882,7 @@ fn install_deletes_legacy_multirust_bins() {
 #[cfg(unix)] // Can't test on windows without clobbering the home dir
 fn legacy_upgrade_installs_to_correct_location() {
     setup(&|config, _, home| {
-        let fake_cargo = config.rustupdir.path().join(".multirust/cargo");
+        let fake_cargo = config.rustupdir.join(".multirust/cargo");
         env::set_var("CARGO_HOME", format!("{}", fake_cargo.display()));
         expect_ok(config, &["multirust-setup", "-y"]);
         let multirust = home.join(&format!(".cargo/bin/multirust{}", EXE_SUFFIX));
@@ -907,9 +905,9 @@ fn multirust_setup_works_with_weird_names() {
     // Browsers often rename bins to e.g. multirust-setup(2).exe.
 
     setup(&|config, cargo_home, _| {
-        let ref old = config.exedir.path().join(
+        let ref old = config.exedir.join(
             &format!("multirust-setup{}", EXE_SUFFIX));
-        let ref new = config.exedir.path().join(
+        let ref new = config.exedir.join(
             &format!("multirust-setup(2){}", EXE_SUFFIX));
         fs::rename(old, new).unwrap();
         expect_ok(config, &["multirust-setup(2)", "-y"]);

--- a/tests/cli-self-update.rs
+++ b/tests/cli-self-update.rs
@@ -531,8 +531,8 @@ fn update_exact() {
         expect_ok(config, &["multirust-setup", "-y"]);
         expect_ok_ex(config, &["multirust", "self", "update"],
 r"",
-r"info: checking for updates
-info: downloading update
+r"info: checking for self-updates
+info: downloading self-update
 info: multirust updated successfully
 ");
     });
@@ -582,7 +582,7 @@ fn update_no_change() {
 
         expect_ok_ex(config, &["multirust", "self", "update"],
 r"",
-r"info: checking for updates
+r"info: checking for self-updates
 info: multirust is already up to date
 ");
 
@@ -666,6 +666,44 @@ fn update_updates_multirust_bin() {
 
         assert!(before_hash != after_hash);
     });
+}
+
+#[test]
+fn rustup_self_updates() {
+    update_setup(&|config, _| {
+        expect_ok(config, &["rustup-setup", "-y"]);
+
+        let ref bin = config.cargodir.join(&format!("bin/multirust{}", EXE_SUFFIX));
+        let before_hash = calc_hash(bin);
+
+        expect_ok(config, &["rustup"]);
+
+        let after_hash = calc_hash(bin);
+
+        assert!(before_hash != after_hash);
+    })
+}
+
+#[test]
+fn rustup_self_update_exact() {
+    update_setup(&|config, _| {
+        expect_ok(config, &["rustup-setup", "-y"]);
+
+        expect_ok_ex(config, &["rustup"],
+r"
+stable unchanged:
+
+1.1.0 (hash-s-2)
+1.1.0 (hash-s-2)
+
+",
+r"info: updating existing install for 'stable'
+info: downloading toolchain manifest
+info: toolchain is already up to date
+info: checking for self-updates
+info: downloading self-update
+");
+    })
 }
 
 // Because self-delete on windows is hard, multirust-setup doesn't

--- a/tests/cli-self-update.rs
+++ b/tests/cli-self-update.rs
@@ -145,7 +145,7 @@ fn bins_are_executable() {
 fn install_creates_cargo_home() {
     setup(&|config, cargo_home, _| {
         fs::remove_dir(cargo_home).unwrap();
-        fs::remove_dir(config.homedir.path()).unwrap();
+        fs::remove_dir(config.rustupdir.path()).unwrap();
         expect_ok(config, &["multirust-setup", "-y"]);
         assert!(cargo_home.exists());
     });
@@ -202,7 +202,7 @@ fn uninstall_deletes_multirust_home() {
         expect_ok(config, &["multirust-setup", "-y"]);
         expect_ok(config, &["multirust", "default", "nightly"]);
         expect_ok(config, &["multirust", "self", "uninstall", "-y"]);
-        assert!(!config.homedir.path().exists());
+        assert!(!config.rustupdir.path().exists());
     });
 }
 
@@ -210,7 +210,7 @@ fn uninstall_deletes_multirust_home() {
 fn uninstall_works_if_multirust_home_doesnt_exist() {
     setup(&|config, _, _| {
         expect_ok(config, &["multirust-setup", "-y"]);
-        fs::remove_dir_all(&config.homedir.path()).unwrap();
+        fs::remove_dir_all(&config.rustupdir.path()).unwrap();
         expect_ok(config, &["multirust", "self", "uninstall", "-y"]);
     });
 }
@@ -845,7 +845,7 @@ fn install_sets_up_stable_unless_there_is_already_a_default() {
 #[cfg(unix)]
 fn install_deletes_legacy_multirust_bins() {
     setup(&|config, _, _| {
-        let ref multirust_bin_dir = config.homedir.path().join("bin");
+        let ref multirust_bin_dir = config.rustupdir.path().join("bin");
         fs::create_dir_all(multirust_bin_dir).unwrap();
         let ref multirust_bin = multirust_bin_dir.join("multirust");
         let ref rustc_bin = multirust_bin_dir.join("rustc");
@@ -884,7 +884,7 @@ fn install_deletes_legacy_multirust_bins() {
 #[cfg(unix)] // Can't test on windows without clobbering the home dir
 fn legacy_upgrade_installs_to_correct_location() {
     setup(&|config, _, home| {
-        let fake_cargo = config.homedir.path().join(".multirust/cargo");
+        let fake_cargo = config.rustupdir.path().join(".multirust/cargo");
         env::set_var("CARGO_HOME", format!("{}", fake_cargo.display()));
         expect_ok(config, &["multirust-setup", "-y"]);
         let multirust = home.join(&format!(".cargo/bin/multirust{}", EXE_SUFFIX));

--- a/tests/cli-v1.rs
+++ b/tests/cli-v1.rs
@@ -163,7 +163,7 @@ fn remove_override_toolchain_error_handling() {
 #[test]
 fn bad_sha_on_manifest() {
     setup(&|config| {
-        let sha_file = config.distdir.path().join("dist/channel-rust-nightly.sha256");
+        let sha_file = config.distdir.join("dist/channel-rust-nightly.sha256");
         let sha_str = multirust_utils::raw::read_file(&sha_file).unwrap();
         let mut sha_bytes = sha_str.into_bytes();
         &mut sha_bytes[..10].clone_from_slice(b"aaaaaaaaaa");
@@ -177,7 +177,7 @@ fn bad_sha_on_manifest() {
 #[test]
 fn bad_sha_on_installer() {
     setup(&|config| {
-        let dir = config.distdir.path().join("dist");
+        let dir = config.distdir.join("dist");
         for file in fs::read_dir(&dir).unwrap() {
             let file = file.unwrap();
             if file.path().to_string_lossy().ends_with(".tar.gz") {
@@ -285,7 +285,7 @@ fn show_override() {
             expect_ok(config, &["multirust", "override", "nightly"]);
 
             let expected_override_dir = fs::canonicalize(tempdir.path()).unwrap();;
-            let expected_toolchain_dir = config.rustupdir.path().join("toolchains").join("nightly");
+            let expected_toolchain_dir = config.rustupdir.join("toolchains").join("nightly");
 
             expect_stdout_ok(config, &["multirust", "show-override"],
                              "override toolchain: nightly");
@@ -326,7 +326,7 @@ fn show_override_from_multirust_toolchain_env_var() {
         let tempdir = TempDir::new("multirusT").unwrap();
         change_dir(tempdir.path(), &|| {
 
-            let expected_toolchain_dir = config.rustupdir.path().join("toolchains").join("beta");
+            let expected_toolchain_dir = config.rustupdir.join("toolchains").join("beta");
 
             expect_ok(config, &["multirust", "update", "beta"]);
             expect_ok(config, &["multirust", "override", "nightly"]);

--- a/tests/cli-v1.rs
+++ b/tests/cli-v1.rs
@@ -396,8 +396,8 @@ fn remove_override_with_multiple_overrides() {
 fn no_update_on_channel_when_date_has_not_changed() {
     setup(&|config| {
         expect_ok(config, &["multirust", "update", "nightly"]);
-        expect_stderr_ok(config, &["multirust", "update", "nightly"],
-                         "already up to date");
+        expect_stdout_ok(config, &["multirust", "update", "nightly"],
+                         "unchanged");
     });
 }
 

--- a/tests/cli-v1.rs
+++ b/tests/cli-v1.rs
@@ -285,7 +285,7 @@ fn show_override() {
             expect_ok(config, &["multirust", "override", "nightly"]);
 
             let expected_override_dir = fs::canonicalize(tempdir.path()).unwrap();;
-            let expected_toolchain_dir = config.homedir.path().join("toolchains").join("nightly");
+            let expected_toolchain_dir = config.rustupdir.path().join("toolchains").join("nightly");
 
             expect_stdout_ok(config, &["multirust", "show-override"],
                              "override toolchain: nightly");
@@ -326,7 +326,7 @@ fn show_override_from_multirust_toolchain_env_var() {
         let tempdir = TempDir::new("multirusT").unwrap();
         change_dir(tempdir.path(), &|| {
 
-            let expected_toolchain_dir = config.homedir.path().join("toolchains").join("beta");
+            let expected_toolchain_dir = config.rustupdir.path().join("toolchains").join("beta");
 
             expect_ok(config, &["multirust", "update", "beta"]);
             expect_ok(config, &["multirust", "override", "nightly"]);

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -288,7 +288,7 @@ fn show_override() {
             expect_ok(config, &["multirust", "override", "nightly"]);
 
             let expected_override_dir = fs::canonicalize(tempdir.path()).unwrap();;
-            let expected_toolchain_dir = config.homedir.path().join("toolchains").join("nightly");
+            let expected_toolchain_dir = config.rustupdir.path().join("toolchains").join("nightly");
 
             expect_stdout_ok(config, &["multirust", "show-override"],
                              "override toolchain: nightly");
@@ -329,7 +329,7 @@ fn show_override_from_multirust_toolchain_env_var() {
         let tempdir = TempDir::new("multirusT").unwrap();
         change_dir(tempdir.path(), &|| {
 
-            let expected_toolchain_dir = config.homedir.path().join("toolchains").join("beta");
+            let expected_toolchain_dir = config.rustupdir.path().join("toolchains").join("beta");
 
             expect_ok(config, &["multirust", "update", "beta"]);
             expect_ok(config, &["multirust", "override", "nightly"]);
@@ -512,7 +512,7 @@ fn add_target() {
         expect_ok(config, &["multirust", "add-target", "nightly", clitools::CROSS_ARCH1]);
         let path = format!("toolchains/nightly/lib/rustlib/{}/lib/libstd.rlib",
                            clitools::CROSS_ARCH1);
-        assert!(config.homedir.path().join(path).exists());
+        assert!(config.rustupdir.path().join(path).exists());
     });
 }
 
@@ -563,7 +563,7 @@ fn add_target_again() {
                                  clitools::CROSS_ARCH1));
         let path = format!("toolchains/nightly/lib/rustlib/{}/lib/libstd.rlib",
                            clitools::CROSS_ARCH1);
-        assert!(config.homedir.path().join(path).exists());
+        assert!(config.rustupdir.path().join(path).exists());
     });
 }
 
@@ -585,7 +585,7 @@ fn remove_target() {
         expect_ok(config, &["multirust", "remove-target", "nightly", clitools::CROSS_ARCH1]);
         let path = format!("toolchains/nightly/lib/rustlib/{}/lib/libstd.rlib",
                            clitools::CROSS_ARCH1);
-        assert!(!config.homedir.path().join(path).exists());
+        assert!(!config.rustupdir.path().join(path).exists());
     });
 }
 

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -165,7 +165,7 @@ fn remove_override_toolchain_error_handling() {
 fn bad_sha_on_manifest() {
     setup(&|config| {
         // Corrupt the sha
-        let sha_file = config.distdir.path().join("dist/channel-rust-nightly.toml.sha256");
+        let sha_file = config.distdir.join("dist/channel-rust-nightly.toml.sha256");
         let sha_str = multirust_utils::raw::read_file(&sha_file).unwrap();
         let mut sha_bytes = sha_str.into_bytes();
         &mut sha_bytes[..10].clone_from_slice(b"aaaaaaaaaa");
@@ -180,7 +180,7 @@ fn bad_sha_on_manifest() {
 fn bad_sha_on_installer() {
     setup(&|config| {
         // Since the v2 sha's are contained in the manifest, corrupt the installer
-        let dir = config.distdir.path().join("dist/2015-01-02");
+        let dir = config.distdir.join("dist/2015-01-02");
         for file in fs::read_dir(&dir).unwrap() {
             let file = file.unwrap();
             if file.path().to_string_lossy().ends_with(".tar.gz") {
@@ -288,7 +288,7 @@ fn show_override() {
             expect_ok(config, &["multirust", "override", "nightly"]);
 
             let expected_override_dir = fs::canonicalize(tempdir.path()).unwrap();;
-            let expected_toolchain_dir = config.rustupdir.path().join("toolchains").join("nightly");
+            let expected_toolchain_dir = config.rustupdir.join("toolchains").join("nightly");
 
             expect_stdout_ok(config, &["multirust", "show-override"],
                              "override toolchain: nightly");
@@ -329,7 +329,7 @@ fn show_override_from_multirust_toolchain_env_var() {
         let tempdir = TempDir::new("multirusT").unwrap();
         change_dir(tempdir.path(), &|| {
 
-            let expected_toolchain_dir = config.rustupdir.path().join("toolchains").join("beta");
+            let expected_toolchain_dir = config.rustupdir.join("toolchains").join("beta");
 
             expect_ok(config, &["multirust", "update", "beta"]);
             expect_ok(config, &["multirust", "override", "nightly"]);
@@ -444,7 +444,7 @@ fn upgrade_v1_to_v2() {
     clitools::setup(Scenario::Full, &|config| {
         set_current_dist_date(config, "2015-01-01");
         // Delete the v2 manifest so the first day we install from the v1s
-        fs::remove_file(config.distdir.path().join("dist/channel-rust-nightly.toml.sha256")).unwrap();
+        fs::remove_file(config.distdir.join("dist/channel-rust-nightly.toml.sha256")).unwrap();
         expect_ok(config, &["multirust", "default", "nightly"]);
         set_current_dist_date(config, "2015-01-02");
         expect_ok(config, &["multirust", "update", "nightly"]);
@@ -459,7 +459,7 @@ fn upgrade_v2_to_v1() {
         set_current_dist_date(config, "2015-01-01");
         expect_ok(config, &["multirust", "default", "nightly"]);
         set_current_dist_date(config, "2015-01-02");
-        fs::remove_file(config.distdir.path().join("dist/channel-rust-nightly.toml.sha256")).unwrap();
+        fs::remove_file(config.distdir.join("dist/channel-rust-nightly.toml.sha256")).unwrap();
         expect_err(config, &["multirust", "update", "nightly"],
                            "the server unexpectedly provided an obsolete version of the distribution manifest");
     });
@@ -485,7 +485,7 @@ fn list_targets_v1_toolchain() {
 #[test]
 fn list_targets_custom_toolchain() {
     setup(&|config| {
-        let path = config.customdir.path().join("custom-1");
+        let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "update", "default-from-path",
                             "--copy-local", &path]);
@@ -512,7 +512,7 @@ fn add_target() {
         expect_ok(config, &["multirust", "add-target", "nightly", clitools::CROSS_ARCH1]);
         let path = format!("toolchains/nightly/lib/rustlib/{}/lib/libstd.rlib",
                            clitools::CROSS_ARCH1);
-        assert!(config.rustupdir.path().join(path).exists());
+        assert!(config.rustupdir.join(path).exists());
     });
 }
 
@@ -544,7 +544,7 @@ fn add_target_v1_toolchain() {
 #[test]
 fn add_target_custom_toolchain() {
     setup(&|config| {
-        let path = config.customdir.path().join("custom-1");
+        let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "update", "default-from-path",
                             "--copy-local", &path]);
@@ -563,7 +563,7 @@ fn add_target_again() {
                                  clitools::CROSS_ARCH1));
         let path = format!("toolchains/nightly/lib/rustlib/{}/lib/libstd.rlib",
                            clitools::CROSS_ARCH1);
-        assert!(config.rustupdir.path().join(path).exists());
+        assert!(config.rustupdir.join(path).exists());
     });
 }
 
@@ -585,7 +585,7 @@ fn remove_target() {
         expect_ok(config, &["multirust", "remove-target", "nightly", clitools::CROSS_ARCH1]);
         let path = format!("toolchains/nightly/lib/rustlib/{}/lib/libstd.rlib",
                            clitools::CROSS_ARCH1);
-        assert!(!config.rustupdir.path().join(path).exists());
+        assert!(!config.rustupdir.join(path).exists());
     });
 }
 
@@ -628,7 +628,7 @@ fn remove_target_v1_toolchain() {
 #[test]
 fn remove_target_custom_toolchain() {
     setup(&|config| {
-        let path = config.customdir.path().join("custom-1");
+        let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
         expect_ok(config, &["multirust", "update", "default-from-path",
                             "--copy-local", &path]);
@@ -663,7 +663,7 @@ fn make_component_unavailable(config: &Config, name: &str, target: &str) {
     use multirust_dist::manifest::Manifest;
     use multirust_mock::dist::create_hash;
 
-    let ref manifest_path = config.distdir.path().join("dist/channel-rust-nightly.toml");
+    let ref manifest_path = config.distdir.join("dist/channel-rust-nightly.toml");
     let ref manifest_str = multirust_utils::raw::read_file(manifest_path).unwrap();
     let mut manifest = Manifest::parse(manifest_str).unwrap();
     {

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -399,8 +399,8 @@ fn remove_override_with_multiple_overrides() {
 fn no_update_on_channel_when_date_has_not_changed() {
     setup(&|config| {
         expect_ok(config, &["multirust", "update", "nightly"]);
-        expect_stderr_ok(config, &["multirust", "update", "nightly"],
-                         "already up to date");
+        expect_stdout_ok(config, &["multirust", "update", "nightly"],
+                         "unchanged");
     });
 }
 


### PR DESCRIPTION
Now there are fewer lines of spew and the final update summary is
condensed. A typical update looks like

```
info: syncing channel updates for 'stable'
info: checking for self-updates
info: downloading self-update

  stable unchanged: 1.1.0 (hash-s-2)

```