### PR TITLE
Deploy to s3. Add simple website.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,10 @@ branches:
 sudo: required
 services:
   - docker
+
 install:
+  - sudo pip install awscli
+  - aws configure set preview.cloudfront true
   # Set git user for pushing binaries
   - git config --global user.email "diggsey@googlemail.com"
   - git config --global user.name "Diggory Blake (via Travis CI)"
@@ -81,40 +84,36 @@ after_success:
       find target/debug/*-* -executable ! -name multirust-rs -exec kcov --verify --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov '{}' \;;
     fi
 
-  # Compute sha-256 hashes of all build artifacts
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-      find "target/release/" -maxdepth 1 -type f -exec sh -c 'shasum -a 256 -b "{}" | cut -d\  -f1 > "{}.sha256"' \;;
-    else
-      find "target/release/" -maxdepth 1 -type f -exec sh -c 'sha256sum -b "{}" | cut -d\  -f1 > "{}.sha256"' \;;
-    fi
+before_deploy:
+  - bash prepare-deploy-travis.sh
 
-  # Build documentation and push release binaries
-  - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" ]]; then
+deploy:
+  - provider: s3
+    bucket: dev-static-rust-lang-org
+    skip_cleanup: true
+    local_dir: deploy
+    upload_dir: rustup
+    acl: public_read
+    region: us-west-1
+    access_key_id: AKIAIZT5ZFS5N2VNRGPA
+    secret_access_key:
+      secure: "CGFWEhkk6siQxW24zJqlXRC4WLQPqXRJ5Rqa6rQNErotorRUn0DnPB+4zYW4KvMTDkv5pPwEv8P6b0IwbY8ZrS7ChfZ6t89xTvuklxsb8PlMwaDXWqkP5cCBT4B/e1S81xSI7ptkQ7Te5bcVbPMVE3MuGYtzhgIaYu+RZMLHSteY2TGnHid7ErmZKmvGoRqootEHYRo4Pv2s2ydZaalzrt8I5uGQPzesJc2T8xWS8VcFAGJTy4p59h5d6Btlo2a5L3Oc8kMLDzsxzwBbrNXQjF7oLZw7g1uf1A7iBrJGsv61GCnggl4+gtEt/BFQ8mtknBLXv3kXBfvrj35YnHAZosZWufSOgsQ9HB7ELjVhRhGRFX2BNKH1Gm/qM0j7WenD3vhOCTzMW21xqEvgY7+KIvyb9XLla7du/0/rZnDoBnCbZNpBOU5NqOV0y6MN6NDL5g168N7M30BeEEcJjbLEXtUTlCp/6jzZj3frDezJNJypniqwRfacf0yKNykVsnpqpcPmQfvxk2I/1BjdukLM5WifAgTEy9IG2/PBUIWr5ikAlhpACxmuKrlExJpOmZRMRjjRjI8tw8bSKu00SbeYT6PO0xazP9oJYKtWi5vkvM9U4R7udeYHTJFAMkeASpOO4Ss6f+dXQzm7OWqFu07Ffm9zHh+WX95PXonlzauEQ1I="
+    on:
+      branch: master
 
-      git config --global credential.helper store;
-      echo "https://${TOKEN}:x-oauth-basic@github.com" >> ~/.git-credentials;
+  - provider: s3
+    bucket: static-rust-lang-org
+    skip_cleanup: true
+    local_dir: deploy
+    upload_dir: rustup
+    acl: public_read
+    region: us-west-1
+    access_key_id: AKIAIZT5ZFS5N2VNRGPA
+    secret_access_key:
+      secure: "CGFWEhkk6siQxW24zJqlXRC4WLQPqXRJ5Rqa6rQNErotorRUn0DnPB+4zYW4KvMTDkv5pPwEv8P6b0IwbY8ZrS7ChfZ6t89xTvuklxsb8PlMwaDXWqkP5cCBT4B/e1S81xSI7ptkQ7Te5bcVbPMVE3MuGYtzhgIaYu+RZMLHSteY2TGnHid7ErmZKmvGoRqootEHYRo4Pv2s2ydZaalzrt8I5uGQPzesJc2T8xWS8VcFAGJTy4p59h5d6Btlo2a5L3Oc8kMLDzsxzwBbrNXQjF7oLZw7g1uf1A7iBrJGsv61GCnggl4+gtEt/BFQ8mtknBLXv3kXBfvrj35YnHAZosZWufSOgsQ9HB7ELjVhRhGRFX2BNKH1Gm/qM0j7WenD3vhOCTzMW21xqEvgY7+KIvyb9XLla7du/0/rZnDoBnCbZNpBOU5NqOV0y6MN6NDL5g168N7M30BeEEcJjbLEXtUTlCp/6jzZj3frDezJNJypniqwRfacf0yKNykVsnpqpcPmQfvxk2I/1BjdukLM5WifAgTEy9IG2/PBUIWr5ikAlhpACxmuKrlExJpOmZRMRjjRjI8tw8bSKu00SbeYT6PO0xazP9oJYKtWi5vkvM9U4R7udeYHTJFAMkeASpOO4Ss6f+dXQzm7OWqFu07Ffm9zHh+WX95PXonlzauEQ1I="
+    on:
+     branch: stable
 
-      if [ "$TARGET" == "x86_64-unknown-linux-gnu" ]; then
-        cargo doc;
-        echo '<meta http-equiv=refresh content=0;url=multirust/index.html>' > target/doc/index.html;
-        sudo pip install ghp-import;
-        ghp-import -n target/doc;
-        git push -qf https://${TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages;
-      fi;
-
-      bin=./binaries/$TARGET;
-
-      git submodule init;
-      git submodule update --depth 1 --remote;
-
-      mkdir -p "$bin";
-      rm $bin/*;
-      find "target/release/" -maxdepth 1 -type f -exec cp "{}" "$bin" \;;
-      git rev-parse HEAD > "$bin/commit.txt";
-
-      cd binaries;
-      git checkout master;
-      git add -A;
-      git commit -m "Auto-update $TRAVIS_BRANCH/$TARGET binaries (Travis CI)";
-      for i in {1..5}; do ./push-changes.sh && break; done;
-    fi
+# FIXME: I don't know if this really works
+after_deploy:
+  - aws cloudfront create-invalidation --paths "rustup/$TARGET/* rustup/dev/$TARGET/* rustup/www/* rustup/dev/www/* rustup/* rustup/dev/*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,11 +64,6 @@ path = "src/multirust/lib.rs"
 test = false # no unit tests
 
 [[bin]]
-name = "multirust-setup"
-path = "src/multirust-cli/main.rs"
-test = false # no unit tests
-
-[[bin]]
-name = "multirust-rs"
+name = "rustup-setup"
 path = "src/multirust-cli/main.rs"
 test = false # no unit tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,33 +44,48 @@ install:
       git config --global push.default simple
 
 build: false
+
 test_script:
   - cargo build  --release
   - cargo test --release -p multirust-dist
   - cargo test --release
+
 notifications:
   - provider: Webhook
     url: https://webhooks.gitter.im/e/9907ad94eb7a5ff291c3
-on_success:
-  - ps: |
-      if ((!$env:APPVEYOR_PULL_REQUEST_NUMBER) -and ($env:APPVEYOR_REPO_BRANCH -eq "master")) {
-        cargo build --release
-        # Generate hashes
-        Get-FileHash .\target\release\* | ForEach-Object {[io.file]::WriteAllText($_.Path + ".sha256", $_.Hash.ToLower() + "`n")}
 
-        $bin = "binaries\$env:TARGET"
+after_test:
+  - powershell -File prepare-deploy-appveyor.ps1
 
-        cmd /c "git config --global credential.helper store 2>&1"
-        Add-Content "$env:USERPROFILE\.git-credentials" "https://$($env:access_token):x-oauth-basic@github.com`n"
-        cmd /c "git submodule init 2>&1"
-        cmd /c "git submodule update --depth 1 --remote 2>&1"
-        if (!(Test-Path -Path "$bin")) { mkdir "$bin" }
-        cmd /c "del /Q `"$bin`""
-        cmd /c "copy /B /Y `"target\release\*`" `"$bin`""
-        cmd /c "git rev-parse HEAD > `"$bin\commit.txt`" 2>&1"
-        cd binaries
-        cmd /c "git checkout master 2>&1"
-        cmd /c "git add -A 2>&1"
-        cmd /c "git commit -m `"Auto-update $env:APPVEYOR_REPO_BRANCH/$env:TARGET binaries (Appveyor CI)`" 2>&1"
-        $attempts = 1; do { .\push-changes.bat; $attempts++ } while($lastexitcode -ne '0' -and $attempts -le 5)
-      }
+artifacts:
+  - path: dist\$(TARGET)\rustup-setup.exe
+    name: rustup-setup
+  - path: dist\$(TARGET)\rustup-setup.exe.sha256
+    name: rustup-setup-sha
+
+deploy:
+  - provider: S3
+    skip_cleanup: true
+    access_key_id: AKIAIZT5ZFS5N2VNRGPA
+    secret_access_key:
+      secure: viw7GCfVF0QlY0fghoxO3Lux/Wo4u6PxxgUwEq5cs4w69tlv9KzIIw74Nc7KJdgt
+    bucket: dev-static-rust-lang-org
+    set_public: true
+    region: us-west-1
+    artifact: rustup-setup,rustup-setup-sha
+    folder: rustup
+    on:
+      branch: master
+
+  - provider: S3
+    skip_cleanup: true
+    access_key_id: AKIAIZT5ZFS5N2VNRGPA
+    secret_access_key:
+      secure: viw7GCfVF0QlY0fghoxO3Lux/Wo4u6PxxgUwEq5cs4w69tlv9KzIIw74Nc7KJdgt
+    bucket: static-rust-lang-org
+    set_public: true
+    region: us-west-1
+    artifact: rustup-setup,rustup-setup-sha
+    folder: rustup
+    on:
+      branch: stable

--- a/prepare-deploy-appveyor.ps1
+++ b/prepare-deploy-appveyor.ps1
@@ -1,0 +1,18 @@
+if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {
+   exit 0
+}
+
+if ($env:APPVEYOR_REPO_BRANCH -eq "auto") {
+   exit 0
+}
+
+# Generate hashes
+Get-FileHash .\target\release\* | ForEach-Object {[io.file]::WriteAllText($_.Path + ".sha256", $_.Hash.ToLower() + "`n")}
+
+# Prepare bins for upload
+$dest = "dist\$env:TARGET"
+md -Force "$dest"
+cp target\release\rustup-setup.exe "$dest/"
+cp target\release\rustup-setup.exe.sha256 "$dest/"
+
+ls "$dest"

--- a/prepare-deploy-travis.sh
+++ b/prepare-deploy-travis.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -u -e
+
+if [ "$TRAVIS_PULL_REQUEST" == "true" ]; then
+    exit 0
+fi
+
+if [ "$TRAVIS_BRANCH" == "auto" ]; then
+    exit 0
+fi
+
+# Upload docs
+if [[ "$TARGET" == "x86_64-unknown-linux-gnu" && "$TRAVIS_BRANCH" == "stable" ]]; then
+    git config --global credential.helper store;
+    echo "https://${TOKEN}:x-oauth-basic@github.com" >> ~/.git-credentials;
+    cargo doc;
+    echo '<meta http-equiv=refresh content=0;url=multirust/index.html>' > target/doc/index.html;
+    sudo pip install ghp-import;
+    ghp-import -n target/doc;
+    git push -qf https://${TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages;
+fi;
+
+# Generate hashes
+if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    find "target/release/" -maxdepth 1 -type f -exec sh -c 'shasum -a 256 -b "{}" > "{}.sha256"' \;;
+else
+    find "target/release/" -maxdepth 1 -type f -exec sh -c 'sha256sum -b "{}" > "{}.sha256"' \;;
+fi
+
+# The directory for deployment artifacts
+dest="deploy"
+
+# Prepare bins for upload
+bindest="$dest/dist/$TARGET"
+mkdir -p "$bindest/"
+cp target/release/rustup-setup "$bindest/"
+cp target/release/rustup-setup.sha256 "$bindest/"
+
+if [ "$TARGET" != "x86_64-unknown-linux-gnu" ]; then
+    exit 0
+fi
+
+cp rustup-setup.sh "$dest/"
+
+# Prepare website for upload
+cp -R www "$dest/www"

--- a/src/multirust-cli/self_update.rs
+++ b/src/multirust-cli/self_update.rs
@@ -142,7 +142,7 @@ static TOOLS: &'static [&'static str]
     = &["rustup", "rustc", "rustdoc", "cargo", "rust-lldb", "rust-gdb"];
 
 static UPDATE_ROOT: &'static str
-    = "https://github.com/Diggsey/multirust-rs-binaries/raw/master";
+    = "https://static.rust-lang.org/rustup/dist";
 
 /// CARGO_HOME suitable for display, possibly with $HOME
 /// substituted for the directory prefix
@@ -803,7 +803,7 @@ pub fn update() -> Result<()> {
 pub fn prepare_update() -> Result<Option<PathBuf>> {
     let ref cargo_home = try!(utils::cargo_home());
     let ref multirust_path = cargo_home.join(&format!("bin/multirust{}", EXE_SUFFIX));
-    let ref setup_path = cargo_home.join(&format!("bin/multirust-setup{}", EXE_SUFFIX));
+    let ref setup_path = cargo_home.join(&format!("bin/rustup-setup{}", EXE_SUFFIX));
 
     if !multirust_path.exists() {
         return Err(Error::NotSelfInstalled(cargo_home.clone()));
@@ -826,7 +826,7 @@ pub fn prepare_update() -> Result<Option<PathBuf>> {
         }));
 
     // Get download URL
-    let url = format!("{}/{}/multirust-setup{}", update_root, triple, EXE_SUFFIX);
+    let url = format!("{}/{}/rustup-setup{}", update_root, triple, EXE_SUFFIX);
 
     // Calculate own hash
     let mut hasher = Hasher::new(Type::SHA256);
@@ -937,10 +937,17 @@ pub fn self_replace() -> Result<()> {
 
 pub fn cleanup_self_updater() -> Result<()> {
     let cargo_home = try!(utils::cargo_home());
-    let ref setup = cargo_home.join(&format!("bin/multirust-setup{}", EXE_SUFFIX));
+    let ref setup = cargo_home.join(&format!("bin/rustup-setup{}", EXE_SUFFIX));
 
     if setup.exists() {
         try!(utils::remove_file("setup", setup));
+    }
+
+    // Transitional
+    let ref old_setup = cargo_home.join(&format!("bin/multirust-setup{}", EXE_SUFFIX));
+
+    if old_setup.exists() {
+        try!(utils::remove_file("setup", old_setup));
     }
 
     Ok(())

--- a/src/multirust-mock/src/clitools.rs
+++ b/src/multirust-mock/src/clitools.rs
@@ -73,7 +73,7 @@ pub fn setup(s: Scenario, f: &Fn(&Config)) {
 
     let current_exe_path = env::current_exe().map(PathBuf::from).unwrap();
     let exe_dir = current_exe_path.parent().unwrap();
-    let ref multirust_build_path = exe_dir.join(format!("multirust-setup{}", EXE_SUFFIX));
+    let ref multirust_build_path = exe_dir.join(format!("rustup-setup{}", EXE_SUFFIX));
 
     let ref multirust_path = config.exedir.join(format!("multirust{}", EXE_SUFFIX));
     let setup_path = config.exedir.join(format!("multirust-setup{}", EXE_SUFFIX));

--- a/tests/cli-self-update.rs
+++ b/tests/cli-self-update.rs
@@ -54,9 +54,9 @@ pub fn update_setup(f: &Fn(&Config, &Path)) {
 
         let ref trip = this_host_triple();
         let ref dist_dir = self_dist.join(&format!("{}", trip));
-        let ref dist_exe = dist_dir.join(&format!("multirust-setup{}", EXE_SUFFIX));
-        let ref dist_hash = dist_dir.join(&format!("multirust-setup{}.sha256", EXE_SUFFIX));
-        let ref multirust_bin = config.exedir.join(&format!("multirust{}", EXE_SUFFIX));
+        let ref dist_exe = dist_dir.join(&format!("rustup-setup{}", EXE_SUFFIX));
+        let ref dist_hash = dist_dir.join(&format!("rustup-setup{}.sha256", EXE_SUFFIX));
+        let ref multirust_bin = config.exedir.join(&format!("rustup-setup{}", EXE_SUFFIX));
 
         fs::create_dir_all(dist_dir).unwrap();
         fs::copy(multirust_bin, dist_exe).unwrap();
@@ -74,7 +74,7 @@ pub fn update_setup(f: &Fn(&Config, &Path)) {
 #[test]
 fn install_bins_to_cargo_home() {
     setup(&|config| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
         let multirust = config.cargodir.join(&format!("bin/multirust{}", EXE_SUFFIX));
         let rustc = config.cargodir.join(&format!("bin/rustc{}", EXE_SUFFIX));
         let rustdoc = config.cargodir.join(&format!("bin/rustdoc{}", EXE_SUFFIX));
@@ -93,8 +93,8 @@ fn install_bins_to_cargo_home() {
 #[test]
 fn install_twice() {
     setup(&|config| {
-        expect_ok(config, &["multirust-setup", "-y"]);
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
         let multirust = config.cargodir.join(&format!("bin/multirust{}", EXE_SUFFIX));
         assert!(multirust.exists());
     });
@@ -104,7 +104,7 @@ fn install_twice() {
 #[cfg(unix)]
 fn bins_are_executable() {
     setup(&|config| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
         let ref multirust = config.cargodir.join(&format!("bin/multirust{}", EXE_SUFFIX));
         let ref rustc = config.cargodir.join(&format!("bin/rustc{}", EXE_SUFFIX));
         let ref rustdoc = config.cargodir.join(&format!("bin/rustdoc{}", EXE_SUFFIX));
@@ -132,7 +132,7 @@ fn install_creates_cargo_home() {
     setup(&|config| {
         fs::remove_dir(&config.cargodir).unwrap();
         fs::remove_dir(&config.rustupdir).unwrap();
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
         assert!(config.cargodir.exists());
     });
 }
@@ -140,7 +140,7 @@ fn install_creates_cargo_home() {
 #[test]
 fn uninstall_deletes_bins() {
     setup(&|config| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
         expect_ok(config, &["multirust", "self", "uninstall", "-y"]);
         let multirust = config.cargodir.join(&format!("bin/multirust{}", EXE_SUFFIX));
         let rustc = config.cargodir.join(&format!("bin/rustc{}", EXE_SUFFIX));
@@ -160,7 +160,7 @@ fn uninstall_deletes_bins() {
 #[test]
 fn uninstall_works_if_some_bins_dont_exist() {
     setup(&|config| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
         let multirust = config.cargodir.join(&format!("bin/multirust{}", EXE_SUFFIX));
         let rustc = config.cargodir.join(&format!("bin/rustc{}", EXE_SUFFIX));
         let rustdoc = config.cargodir.join(&format!("bin/rustdoc{}", EXE_SUFFIX));
@@ -185,7 +185,7 @@ fn uninstall_works_if_some_bins_dont_exist() {
 #[test]
 fn uninstall_deletes_multirust_home() {
     setup(&|config| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
         expect_ok(config, &["multirust", "default", "nightly"]);
         expect_ok(config, &["multirust", "self", "uninstall", "-y"]);
         assert!(!config.rustupdir.exists());
@@ -195,7 +195,7 @@ fn uninstall_deletes_multirust_home() {
 #[test]
 fn uninstall_works_if_multirust_home_doesnt_exist() {
     setup(&|config| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
         fs::remove_dir_all(&config.rustupdir).unwrap();
         expect_ok(config, &["multirust", "self", "uninstall", "-y"]);
     });
@@ -204,7 +204,7 @@ fn uninstall_works_if_multirust_home_doesnt_exist() {
 #[test]
 fn uninstall_deletes_cargo_home() {
     setup(&|config| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
         expect_ok(config, &["multirust", "self", "uninstall", "-y"]);
         assert!(!config.cargodir.exists());
     });
@@ -213,7 +213,7 @@ fn uninstall_deletes_cargo_home() {
 #[test]
 fn uninstall_fails_if_not_installed() {
     setup(&|config| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
         let multirust = config.cargodir.join(&format!("bin/multirust{}", EXE_SUFFIX));
         fs::remove_file(&multirust).unwrap();
         expect_err(config, &["multirust", "self", "uninstall", "-y"],
@@ -227,7 +227,7 @@ fn uninstall_fails_if_not_installed() {
 #[test]
 fn uninstall_self_delete_works() {
     setup(&|config| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
         let multirust = config.cargodir.join(&format!("bin/multirust{}", EXE_SUFFIX));
         let mut cmd = Command::new(multirust.clone());
         cmd.args(&["self", "uninstall", "-y"]);
@@ -258,7 +258,7 @@ fn uninstall_self_delete_works() {
 #[test]
 fn uninstall_doesnt_leave_gc_file() {
     setup(&|config| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
         expect_ok(config, &["multirust", "self", "uninstall", "-y"]);
 
         let ref parent = config.cargodir.parent().unwrap();
@@ -282,7 +282,7 @@ fn install_adds_path_to_rc(rcfile: &str) {
         let my_rc = "foo\nbar\nbaz";
         let ref rc = config.homedir.join(rcfile);
         raw::write_file(rc, my_rc).unwrap();
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
 
         let new_rc = raw::read_file(rc).unwrap();
         let addition = format!(r#"export PATH="{}/bin:$PATH""#,
@@ -317,7 +317,7 @@ fn install_does_not_add_paths_to_rcfiles_that_dont_exist() {
         let my_bashrc = "foo\nbar\nbaz";
         let ref bashrc = config.homedir.join(".bashrc");
         raw::write_file(bashrc, my_bashrc).unwrap();
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
 
         let ref zshrc = config.homedir.join(".zshrc");
         let ref kshrc = config.homedir.join(".kshrc");
@@ -338,8 +338,8 @@ fn install_adds_path_to_rcfile_just_once() {
         let my_bashrc = "foo\nbar\nbaz";
         let ref bashrc = config.homedir.join(".bashrc");
         raw::write_file(bashrc, my_bashrc).unwrap();
-        expect_ok(config, &["multirust-setup", "-y"]);
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
 
         let new_bashrc = raw::read_file(bashrc).unwrap();
         let addition = format!(r#"export PATH="{}/bin:$PATH""#,
@@ -354,7 +354,7 @@ fn install_adds_path_to_rcfile_just_once() {
 #[cfg(unix)]
 fn install_when_no_path_methods() {
     setup(&|config| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
 
         for rc in &[".bashrc", ".zshrc", ".kshrc"] {
             assert!(!config.homedir.join(rc).exists());
@@ -368,7 +368,7 @@ fn uninstall_removes_path_from_rc(rcfile: &str) {
         let my_rc = "foo\nbar\nbaz";
         let ref rc = config.homedir.join(rcfile);
         raw::write_file(rc, my_rc).unwrap();
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
         expect_ok(config, &["multirust", "self", "uninstall", "-y"]);
 
         let new_rc = raw::read_file(rc).unwrap();
@@ -401,7 +401,7 @@ fn uninstall_doesnt_touch_rc_files_that_dont_exist() {
         let my_rc = "foo\nbar\nbaz";
         let ref bashrc = config.homedir.join(".bashrc");
         raw::write_file(bashrc, my_rc).unwrap();
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
         expect_ok(config, &["multirust", "self", "uninstall", "-y"]);
 
         let ref zshrc = config.homedir.join(".zshrc");
@@ -418,7 +418,7 @@ fn uninstall_doesnt_touch_rc_files_that_dont_contain_cargo_home() {
         let my_rc = "foo\nbar\nbaz";
         let ref bashrc = config.homedir.join(".bashrc");
         raw::write_file(bashrc, my_rc).unwrap();
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
 
         let ref zshrc = config.homedir.join(".zshrc");
         raw::write_file(zshrc, my_rc).unwrap();
@@ -444,7 +444,7 @@ fn when_cargo_home_is_the_default_write_path_specially() {
         let my_bashrc = "foo\nbar\nbaz";
         let ref bashrc = config.homedir.join(".bashrc");
         raw::write_file(bashrc, my_bashrc).unwrap();
-        let mut cmd = clitools::cmd(config, "multirust-setup", &["-y"]);
+        let mut cmd = clitools::cmd(config, "rustup-setup", &["-y"]);
         cmd.env_remove("CARGO_HOME");
         assert!(cmd.output().unwrap().status.success());
 
@@ -494,7 +494,7 @@ fn restore_path(_: &str) { }
 #[cfg(windows)]
 fn install_adds_path() {
     setup(&|config| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
 
         let path = config.cargodir.join("bin").to_string_lossy().to_string();
         assert!(get_path().contains(&path));
@@ -505,8 +505,8 @@ fn install_adds_path() {
 #[cfg(windows)]
 fn install_does_not_add_path_twice() {
     setup(&|config| {
-        expect_ok(config, &["multirust-setup", "-y"]);
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
 
         let path = config.cargodir.join("bin").to_string_lossy().to_string();
         assert_eq!(get_path().matches(&path).count(), 1);
@@ -517,7 +517,7 @@ fn install_does_not_add_path_twice() {
 #[cfg(windows)]
 fn uninstall_removes_path() {
     setup(&|config| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
         expect_ok(config, &["multirust", "self", "uninstall", "-y"]);
 
         let path = config.cargodir.join("bin").to_string_lossy().to_string();
@@ -528,7 +528,7 @@ fn uninstall_removes_path() {
 #[test]
 fn update_exact() {
     update_setup(&|config, _| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
         expect_ok_ex(config, &["multirust", "self", "update"],
 r"",
 r"info: checking for self-updates
@@ -553,9 +553,9 @@ r"error: multirust is not installed at '{}'
 fn update_but_delete_existing_updater_first() {
     update_setup(&|config, _| {
         // The updater is stored in a known location
-        let ref setup = config.cargodir.join(&format!("bin/multirust-setup{}", EXE_SUFFIX));
+        let ref setup = config.cargodir.join(&format!("bin/rustup-setup{}", EXE_SUFFIX));
 
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
 
         // If it happens to already exist for some reason it
         // should just be deleted.
@@ -570,12 +570,12 @@ fn update_but_delete_existing_updater_first() {
 #[test]
 fn update_no_change() {
     update_setup(&|config, self_dist| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
 
         let ref trip = this_host_triple();
         let ref dist_dir = self_dist.join(&format!("{}", trip));
-        let ref dist_exe = dist_dir.join(&format!("multirust-setup{}", EXE_SUFFIX));
-        let ref dist_hash = dist_dir.join(&format!("multirust-setup{}.sha256", EXE_SUFFIX));
+        let ref dist_exe = dist_dir.join(&format!("rustup-setup{}", EXE_SUFFIX));
+        let ref dist_hash = dist_dir.join(&format!("rustup-setup{}.sha256", EXE_SUFFIX));
         let ref multirust_bin = config.exedir.join(&format!("multirust{}", EXE_SUFFIX));
         fs::copy(multirust_bin, dist_exe).unwrap();
         create_hash(dist_exe, dist_hash);
@@ -592,11 +592,11 @@ info: multirust is already up to date
 #[test]
 fn update_bad_hash() {
     update_setup(&|config, self_dist| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
 
         let ref trip = this_host_triple();
         let ref dist_dir = self_dist.join(&format!("{}", trip));
-        let ref dist_hash = dist_dir.join(&format!("multirust-setup{}.sha256", EXE_SUFFIX));
+        let ref dist_hash = dist_dir.join(&format!("rustup-setup{}.sha256", EXE_SUFFIX));
 
         let ref some_other_file = config.distdir.join("dist/channel-rust-nightly.toml");
 
@@ -610,11 +610,11 @@ fn update_bad_hash() {
 #[test]
 fn update_hash_file_404() {
     update_setup(&|config, self_dist| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
 
         let ref trip = this_host_triple();
         let ref dist_dir = self_dist.join(&format!("{}", trip));
-        let ref dist_hash = dist_dir.join(&format!("multirust-setup{}.sha256", EXE_SUFFIX));
+        let ref dist_hash = dist_dir.join(&format!("rustup-setup{}.sha256", EXE_SUFFIX));
 
         fs::remove_file(dist_hash).unwrap();
 
@@ -626,11 +626,11 @@ fn update_hash_file_404() {
 #[test]
 fn update_download_404() {
     update_setup(&|config, self_dist| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
 
         let ref trip = this_host_triple();
         let ref dist_dir = self_dist.join(&format!("{}", trip));
-        let ref dist_exe = dist_dir.join(&format!("multirust-setup{}", EXE_SUFFIX));
+        let ref dist_exe = dist_dir.join(&format!("rustup-setup{}", EXE_SUFFIX));
 
         fs::remove_file(dist_exe).unwrap();
 
@@ -645,7 +645,7 @@ fn update_download_404() {
 #[test]
 fn update_updates_multirust_bin() {
     update_setup(&|config, _| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
 
         let ref bin = config.cargodir.join(&format!("bin/multirust{}", EXE_SUFFIX));
         let before_hash = calc_hash(bin);
@@ -701,17 +701,17 @@ info: downloading self-update
     })
 }
 
-// Because self-delete on windows is hard, multirust-setup doesn't
+// Because self-delete on windows is hard, rustup-setup doesn't
 // do it. It instead leaves itself installed for cleanup by later
 // invocations of multirust.
 #[test]
 fn updater_leaves_itself_for_later_deletion() {
     update_setup(&|config, _| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
         expect_ok(config, &["multirust", "update", "nightly"]);
         expect_ok(config, &["multirust", "self", "update"]);
 
-        let setup = config.cargodir.join(&format!("bin/multirust-setup{}", EXE_SUFFIX));
+        let setup = config.cargodir.join(&format!("bin/rustup-setup{}", EXE_SUFFIX));
         assert!(setup.exists());
     });
 }
@@ -719,13 +719,13 @@ fn updater_leaves_itself_for_later_deletion() {
 #[test]
 fn updater_is_deleted_after_running_multirust() {
     update_setup(&|config, _| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
         expect_ok(config, &["multirust", "update", "nightly"]);
         expect_ok(config, &["multirust", "self", "update"]);
 
         expect_ok(config, &["multirust", "update", "nightly"]);
 
-        let setup = config.cargodir.join(&format!("bin/multirust-setup{}", EXE_SUFFIX));
+        let setup = config.cargodir.join(&format!("bin/rustup-setup{}", EXE_SUFFIX));
         assert!(!setup.exists());
     });
 }
@@ -733,13 +733,13 @@ fn updater_is_deleted_after_running_multirust() {
 #[test]
 fn updater_is_deleted_after_running_rustc() {
     update_setup(&|config, _| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
         expect_ok(config, &["multirust", "default", "nightly"]);
         expect_ok(config, &["multirust", "self", "update"]);
 
         expect_ok(config, &["rustc", "--version"]);
 
-        let setup = config.cargodir.join(&format!("bin/multirust-setup{}", EXE_SUFFIX));
+        let setup = config.cargodir.join(&format!("bin/rustup-setup{}", EXE_SUFFIX));
         assert!(!setup.exists());
     });
 }
@@ -747,7 +747,7 @@ fn updater_is_deleted_after_running_rustc() {
 #[test]
 fn multirust_still_works_after_update() {
     update_setup(&|config, _| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
         expect_ok(config, &["multirust", "default", "nightly"]);
         expect_ok(config, &["multirust", "self", "update"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
@@ -767,7 +767,7 @@ fn update_stress_test() {
 #[test]
 fn first_install_exact() {
     setup(&|config| {
-        expect_ok_ex(config, &["multirust-setup", "-y"],
+        expect_ok_ex(config, &["rustup-setup", "-y"],
 r"
   stable installed: 1.1.0 (hash-s-2)
 
@@ -790,8 +790,8 @@ info: default toolchain set to 'stable'
 #[test]
 fn reinstall_exact() {
     setup(&|config| {
-        expect_ok(config, &["multirust-setup", "-y"]);
-        expect_ok_ex(config, &["multirust-setup", "-y"],
+        expect_ok(config, &["rustup-setup", "-y"]);
+        expect_ok_ex(config, &["rustup-setup", "-y"],
 r"",
 r"info: updating existing installation
 "
@@ -807,7 +807,7 @@ fn produces_env_file_on_unix() {
         // $HOME/.cargo by removing CARGO_HOME from the environment,
         // otherwise the literal path will be written to the file.
 
-        let mut cmd = clitools::cmd(config, "multirust-setup", &["-y"]);
+        let mut cmd = clitools::cmd(config, "rustup-setup", &["-y"]);
         cmd.env_remove("CARGO_HOME");
         assert!(cmd.output().unwrap().status.success());
         let ref envfile = config.homedir.join(".cargo/env");
@@ -824,7 +824,7 @@ fn doesnt_produce_env_file_on_windows() {
 #[test]
 fn install_sets_up_stable() {
     setup(&|config| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
         expect_stdout_ok(config, &["rustc", "--version"],
                          "hash-s-2");
     });
@@ -833,10 +833,10 @@ fn install_sets_up_stable() {
 #[test]
 fn install_sets_up_stable_unless_there_is_already_a_default() {
     setup(&|config| {
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
         expect_ok(config, &["multirust", "default", "nightly"]);
         expect_ok(config, &["multirust", "remove-toolchain", "stable"]);
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
         expect_stdout_ok(config, &["rustc", "--version"],
                          "hash-n-2");
         expect_err(config, &["multirust", "run", "stable", "rustc", "--version"],
@@ -859,7 +859,7 @@ fn install_deletes_legacy_multirust_bins() {
         raw::write_file(rustc_bin, "").unwrap();
         assert!(multirust_bin.exists());
         assert!(rustc_bin.exists());
-        expect_ok(config, &["multirust-setup", "-y"]);
+        expect_ok(config, &["rustup-setup", "-y"]);
         assert!(!multirust_bin.exists());
         assert!(!rustc_bin.exists());
     });
@@ -880,7 +880,7 @@ fn install_deletes_legacy_multirust_bins() {
     // windows::get_special_folder(&windows::FOLDERID_Profile).unwrap();
 }
 
-// multirust-setup obeys CONFIG.CARGODIR, which multirust-rs *used* to set
+// rustup-setup obeys CONFIG.CARGODIR, which multirust-rs *used* to set
 // before installation moved from ~/.multirust/bin to ~/.cargo/bin.
 // If installation running under the old multirust via `cargo run`,
 // then CONFIG.CARGODIR will be set during installation, causing the
@@ -891,7 +891,7 @@ fn install_deletes_legacy_multirust_bins() {
 fn legacy_upgrade_installs_to_correct_location() {
     setup(&|config| {
         let fake_cargo = config.rustupdir.join(".multirust/cargo");
-        let mut cmd = clitools::cmd(config, "multirust-setup", &["-y"]);
+        let mut cmd = clitools::cmd(config, "rustup-setup", &["-y"]);
         cmd.env("CARGO_HOME", format!("{}", fake_cargo.display()));
         assert!(cmd.output().unwrap().status.success());
 
@@ -905,22 +905,22 @@ fn legacy_upgrade_installs_to_correct_location() {
 #[test]
 fn readline_no_stdin() {
     setup(&|config| {
-        expect_err(config, &["multirust-setup"],
+        expect_err(config, &["rustup-setup"],
                    "unable to read from stdin for confirmation");
     });
 }
 
 #[test]
 fn multirust_setup_works_with_weird_names() {
-    // Browsers often rename bins to e.g. multirust-setup(2).exe.
+    // Browsers often rename bins to e.g. rustup-setup(2).exe.
 
     setup(&|config| {
         let ref old = config.exedir.join(
-            &format!("multirust-setup{}", EXE_SUFFIX));
+            &format!("rustup-setup{}", EXE_SUFFIX));
         let ref new = config.exedir.join(
-            &format!("multirust-setup(2){}", EXE_SUFFIX));
+            &format!("rustup-setup(2){}", EXE_SUFFIX));
         fs::rename(old, new).unwrap();
-        expect_ok(config, &["multirust-setup(2)", "-y"]);
+        expect_ok(config, &["rustup-setup(2)", "-y"]);
         let multirust = config.cargodir.join(&format!("bin/multirust{}", EXE_SUFFIX));
         assert!(multirust.exists());
     });

--- a/www/index.html
+++ b/www/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+
+<head>
+  <meta charset="utf-8">
+  <title>rustup.rs - Update your Rust</title>
+  <meta name="keywords" content="Rust, Rust programming language, rustlang, rust-lang, Mozilla Rust, rustup">
+  <meta name="description" content="The Rust toolchain installer">
+
+  <link rel="stylesheet" href="normalize.css">
+  <link rel="stylesheet" href="rustup.css">
+
+</head>
+
+<body id="idx">
+
+<p id="pitch">
+  This is the ultimate way to install
+  <a href="https://www.rust-lang.org">Rust</a>
+  the systems programming language<br/>
+  that runs blazingly fast,<br/>
+  prevents segfaults,<br/>
+  and guarantees thread safety.
+</p>
+
+<div id="platform-instructions-unix" style="display: none;">
+  <p>Run the following in your terminal, then follow the onscreen instructions.</p>
+  <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+</div>
+
+<div id="platform-instructions-win" style="display: none;">
+  <p>
+    Download and run
+    <a href="https://win.rustup.rs">rustup&#x2011;setup.exe</a>
+    then follow the onscreen instructions.
+  </p>
+</div>
+
+<div id="platform-instructions-unknown">
+  <p>I don't recognize your platform.</p>
+  <p>
+    rustup supports Windows, Linux, and Mac OS X. If you <em>are</em>
+    on one of these platforms and are seeing this then either
+    JavaScript is disabled or this website is drunk and
+    <a href="https://github.com/rust-lang-nursery/multirust-rs/issues/new">should be reported.</a>
+  </p>
+</div>
+
+<p id="help">
+  Need help?<br/><a href="https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners">Ask on #rust-beginners</a>.
+</p>
+
+<p id="about">
+  <a href="https://github.com/rust-lang-nursery/multirust-rs/blob/master/README.md">More about rustup</a>.
+</p>
+
+<script type="text/javascript" src="rustup.js"></script>

--- a/www/normalize.css
+++ b/www/normalize.css
@@ -1,0 +1,427 @@
+/*! normalize.css v3.0.2 | MIT License | git.io/normalize */
+
+/**
+ * 1. Set default font family to sans-serif.
+ * 2. Prevent iOS text size adjust after orientation change, without disabling
+ *    user zoom.
+ */
+
+html {
+  font-family: sans-serif; /* 1 */
+  -ms-text-size-adjust: 100%; /* 2 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+}
+
+/**
+ * Remove default margin.
+ */
+
+body {
+  margin: 0;
+}
+
+/* HTML5 display definitions
+   ========================================================================== */
+
+/**
+ * Correct `block` display not defined for any HTML5 element in IE 8/9.
+ * Correct `block` display not defined for `details` or `summary` in IE 10/11
+ * and Firefox.
+ * Correct `block` display not defined for `main` in IE 11.
+ */
+
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+menu,
+nav,
+section,
+summary {
+  display: block;
+}
+
+/**
+ * 1. Correct `inline-block` display not defined in IE 8/9.
+ * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
+ */
+
+audio,
+canvas,
+progress,
+video {
+  display: inline-block; /* 1 */
+  vertical-align: baseline; /* 2 */
+}
+
+/**
+ * Prevent modern browsers from displaying `audio` without controls.
+ * Remove excess height in iOS 5 devices.
+ */
+
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+/**
+ * Address `[hidden]` styling not present in IE 8/9/10.
+ * Hide the `template` element in IE 8/9/11, Safari, and Firefox < 22.
+ */
+
+[hidden],
+template {
+  display: none;
+}
+
+/* Links
+   ========================================================================== */
+
+/**
+ * Remove the gray background color from active links in IE 10.
+ */
+
+a {
+  background-color: transparent;
+}
+
+/**
+ * Improve readability when focused and also mouse hovered in all browsers.
+ */
+
+a:active,
+a:hover {
+  outline: 0;
+}
+
+/* Text-level semantics
+   ========================================================================== */
+
+/**
+ * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
+ */
+
+abbr[title] {
+  border-bottom: 1px dotted;
+}
+
+/**
+ * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
+ */
+
+b,
+strong {
+  font-weight: bold;
+}
+
+/**
+ * Address styling not present in Safari and Chrome.
+ */
+
+dfn {
+  font-style: italic;
+}
+
+/**
+ * Address variable `h1` font-size and margin within `section` and `article`
+ * contexts in Firefox 4+, Safari, and Chrome.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/**
+ * Address styling not present in IE 8/9.
+ */
+
+mark {
+  background: #ff0;
+  color: #000;
+}
+
+/**
+ * Address inconsistent and variable font size in all browsers.
+ */
+
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` affecting `line-height` in all browsers.
+ */
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sup {
+  top: -0.5em;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+/* Embedded content
+   ========================================================================== */
+
+/**
+ * Remove border when inside `a` element in IE 8/9/10.
+ */
+
+img {
+  border: 0;
+}
+
+/**
+ * Correct overflow not hidden in IE 9/10/11.
+ */
+
+svg:not(:root) {
+  overflow: hidden;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
+ * Address margin not present in IE 8/9 and Safari.
+ */
+
+figure {
+  margin: 1em 40px;
+}
+
+/**
+ * Address differences between Firefox and other browsers.
+ */
+
+hr {
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
+  height: 0;
+}
+
+/**
+ * Contain overflow in all browsers.
+ */
+
+pre {
+  overflow: auto;
+}
+
+/**
+ * Address odd `em`-unit font size rendering in all browsers.
+ */
+
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+
+/* Forms
+   ========================================================================== */
+
+/**
+ * Known limitation: by default, Chrome and Safari on OS X allow very limited
+ * styling of `select`, unless a `border` property is set.
+ */
+
+/**
+ * 1. Correct color not being inherited.
+ *    Known issue: affects color of disabled elements.
+ * 2. Correct font properties not being inherited.
+ * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit; /* 1 */
+  font: inherit; /* 2 */
+  margin: 0; /* 3 */
+}
+
+/**
+ * Address `overflow` set to `hidden` in IE 8/9/10/11.
+ */
+
+button {
+  overflow: visible;
+}
+
+/**
+ * Address inconsistent `text-transform` inheritance for `button` and `select`.
+ * All other form control elements do not inherit `text-transform` values.
+ * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
+ * Correct `select` style inheritance in Firefox.
+ */
+
+button,
+select {
+  text-transform: none;
+}
+
+/**
+ * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+ *    and `video` controls.
+ * 2. Correct inability to style clickable `input` types in iOS.
+ * 3. Improve usability and consistency of cursor style between image-type
+ *    `input` and others.
+ */
+
+button,
+html input[type="button"], /* 1 */
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button; /* 2 */
+  cursor: pointer; /* 3 */
+}
+
+/**
+ * Re-set default cursor for disabled elements.
+ */
+
+button[disabled],
+html input[disabled] {
+  cursor: default;
+}
+
+/**
+ * Remove inner padding and border in Firefox 4+.
+ */
+
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+/**
+ * Address Firefox 4+ setting `line-height` on `input` using `!important` in
+ * the UA stylesheet.
+ */
+
+input {
+  line-height: normal;
+}
+
+/**
+ * It's recommended that you don't attempt to style these elements.
+ * Firefox's implementation doesn't respect box-sizing, padding, or width.
+ *
+ * 1. Address box sizing set to `content-box` in IE 8/9/10.
+ * 2. Remove excess padding in IE 8/9/10.
+ */
+
+input[type="checkbox"],
+input[type="radio"] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Fix the cursor style for Chrome's increment/decrement buttons. For certain
+ * `font-size` values of the `input`, it causes the cursor style of the
+ * decrement button to change from `default` to `text`.
+ */
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
+ * 2. Address `box-sizing` set to `border-box` in Safari and Chrome
+ *    (include `-moz` to future-proof).
+ */
+
+input[type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  -moz-box-sizing: content-box;
+  -webkit-box-sizing: content-box; /* 2 */
+  box-sizing: content-box;
+}
+
+/**
+ * Remove inner padding and search cancel button in Safari and Chrome on OS X.
+ * Safari (but not Chrome) clips the cancel button when the search input has
+ * padding (and `textfield` appearance).
+ */
+
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * Define consistent border, margin, and padding.
+ */
+
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+
+/**
+ * 1. Correct `color` not being inherited in IE 8/9/10/11.
+ * 2. Remove padding so people aren't caught out if they zero out fieldsets.
+ */
+
+legend {
+  border: 0; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Remove default vertical scrollbar in IE 8/9/10/11.
+ */
+
+textarea {
+  overflow: auto;
+}
+
+/**
+ * Don't inherit the `font-weight` (applied by a rule above).
+ * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
+ */
+
+optgroup {
+  font-weight: bold;
+}
+
+/* Tables
+   ========================================================================== */
+
+/**
+ * Remove most spacing between table cells.
+ */
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+td,
+th {
+  padding: 0;
+}

--- a/www/rustup.css
+++ b/www/rustup.css
@@ -1,0 +1,100 @@
+@import url(https://fonts.googleapis.com/css?family=Cutive+Mono:400);
+@import url(https://fonts.googleapis.com/css?family=Work+Sans:700);
+@import url(https://fonts.googleapis.com/css?family=Source+Code+Pro:500);
+@import url(https://fonts.googleapis.com/css?family=Montserrat:400);
+
+body {
+    margin-top: 3em;
+    background-color: #343838;
+    color: white;
+    font-family: "Cutive Mono", monospace;
+    font-weight: 400;
+    font-size: 20pt;
+}
+
+pre {
+    font-family: "Source Code Pro", monospace;
+    font-weight: 500;
+}
+
+body#idx p {
+    text-shadow: 2px 2px #242828;
+}
+
+body#idx #pitch > a {
+    margin-top: 0.3em;
+    margin-bottom: 0.3em;
+    display: block;
+    font-family: "Work Sans", monospace;
+    font-variant: small-caps;
+    font-size: 300%;
+    font-weight: 700;
+    text-shadow: 4px 3px #242828;
+    text-transform: lowercase;
+    letter-spacing: 0.2em;
+}
+
+a {
+    color: #70EFFC;
+    text-decoration: none;
+}
+
+body#idx a {
+    text-shadow: 2px 2px #242828;
+}
+
+body#idx > * {
+    margin-left: auto;
+    margin-right: auto;
+    text-align: center;
+    width: 25em;;
+}
+
+body#idx > #pitch {
+    width: 30em;
+}
+
+body#idx p {
+    margin-top: 2em;
+    margin-bottom: 2em;
+}
+
+body#idx > #platform-instructions-unix {
+    margin-left: auto;
+    margin-right: auto;
+    width: 30em;
+}
+
+#platform-instructions-unix > * {
+    margin-left: auto;
+    margin-right: auto;
+    width: 25em;;
+}
+
+#platform-instructions-unix > pre {
+    margin-left: auto;
+    margin-right: auto;
+    padding-top: 1em;
+    padding-bottom: 1em;
+    width: 30em;
+    background-color: #D0FFFF;
+    color: #002F3B;
+    text-align: center;
+    border-radius: 3px;
+    box-shadow: inset 0px 0px 10px 0px #70EFFC;
+}
+
+#platform-instructions-win a {
+    display: block;
+    padding-top: 0.4em;
+    padding-bottom: 0.6em;
+    font-family: "Source Code Pro", monospace;
+}
+
+#about {
+    font-size: 70%;
+    text-shadow: 1px 1px #242828;
+}
+#about > a {
+    text-shadow: 1px 1px #242828;
+}

--- a/www/rustup.js
+++ b/www/rustup.js
@@ -1,0 +1,35 @@
+function detect_platform() {
+    "use strict";
+    var os = "unknown";
+
+    if (os == "unknown") {
+	if (navigator.platform == "Linux x86_64") {os = "unix";}
+	if (navigator.platform == "Linux i686") {os = "unix";}
+    }
+
+    // I wish I knew by now, but I don't. Try harder.
+    if (os == "unknown") {
+	if (navigator.appVersion.indexOf("Win")!=-1) {os = "win";}
+	if (navigator.appVersion.indexOf("Mac")!=-1) {os = "unix";}
+	if (navigator.appVersion.indexOf("Linux")!=-1) {os = "unix";}
+    }
+
+    return os;
+}
+
+(function () {
+    "use strict";
+    var platform = detect_platform();
+
+    var unix_div = document.getElementById("platform-instructions-unix");
+    var win_div = document.getElementById("platform-instructions-win");
+    var unknown_div = document.getElementById("platform-instructions-unknown");
+
+    if (platform == "unix") {
+	unix_div.style.display = "block";
+	unknown_div.style.display = "none";
+    } else if (platform == "win") {
+	win_div.style.display = "block";
+	unknown_div.style.display = "none";
+    }
+}());


### PR DESCRIPTION
Name the setup program `rustup-setup.exe`. Modify travis and appveyor
configs to deploy it from master to dev-static.rust-lang.org, and from
the stable branch to static.rust-lang.org.

The directory structure under s3 is

```
rustup/
  www/ - the (simple) website
  rustup-setup.sh - the curlable script
  dist/$target/
    rustup-setup$exe
    rustup-setup$exe.sha256
```

The shell script and website are deployed from x86_64-linux.

Self upgrades are directed to

> https://static.rust-lang.org/rustup/dist/$target/

The rustup-setup.sh script is accessible via sh.rustup.rs,
one of the windows bins at win.rustup.rs, and the website
at www.rustup.rs.

The website is really simple. It does platform detection
and says how to use sh.rustup.rs or win.rustup.rs.

The website is not necessarily final, but I'm probably
not going to think much more about it before asking
for testing and feedback.

Once this is deployed I will do a one-time deployment of the
bins to the old upgrade location to provide continuity.

This probably shouldn't be merged yet because it's late and I should think harder about whether it's really ready.