### PR TITLE
Put the target triple at the end of toolchain names

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,13 @@ SUBCOMMANDS:
 
 Standard toolchain names have the following form:
 ```
-[<arch>-][<os>-][<env>-]<channel>[-<date>]
+<channel>[-<date>][-<arch>][-<os>][-<env>]
 
+<channel>	= stable|beta|nightly
+<date>		= YYYY-MM-DD
 <arch>		= i686|x86_64
 <os>		= pc-windows|unknown-linux|apple-darwin
 <env>		= gnu|msvc
-<channel>	= stable|beta|nightly
-<date>		= YYYY-MM-DD
 ```
 
 Any combination of optional parts are acceptable.
@@ -137,16 +137,16 @@ multirust-rs:
 	`multirust default nightly`
 
 - For the current directory, use the most recent stable build using the MSVC linker:
-	`multirust override msvc-stable`
+	`multirust override stable-msvc`
 
 - For the current directory, use a 32-bit beta build instead:
-	`multirust override i686-beta`
+	`multirust override beta-i686`
 
 - For the current directory, use a nightly from a specific date:
 	`multirust override nightly-2015-04-01`
 
 - Combine these:
-	`multirust override i686-msvc-nightly-2015-04-01`
+	`multirust override nightly-2015-04-01-i686-msvc`
 
 - Install a custom toolchain using an installer:
 	`multirust override my_custom_toolchain --install "/home/user/RustInstaller.tar.gz"`

--- a/src/multirust-dist/src/dist.rs
+++ b/src/multirust-dist/src/dist.rs
@@ -21,26 +21,26 @@ pub const UPDATE_HASH_LEN: usize = 20;
 
 #[derive(Debug)]
 pub struct ToolchainDesc {
-    pub arch: Option<String>,
-    pub os: Option<String>,
-    pub env: Option<String>,
     // Either "nightly", "stable", "beta", or an explicit version number
     pub channel: String,
     pub date: Option<String>,
+    pub arch: Option<String>,
+    pub os: Option<String>,
+    pub env: Option<String>,
 }
 
 impl ToolchainDesc {
     pub fn from_str(name: &str) -> Result<Self> {
-        let archs = ["i686", "x86_64"];
-        let oses = ["pc-windows", "unknown-linux", "apple-darwin"];
-        let envs = ["gnu", "msvc"];
         let channels = ["nightly", "beta", "stable",
                         r"\d{1}\.\d{1}\.\d{1}",
                         r"\d{1}\.\d{2}\.\d{1}"];
+        let archs = ["i686", "x86_64"];
+        let oses = ["pc-windows", "unknown-linux", "apple-darwin"];
+        let envs = ["gnu", "msvc"];
 
         let pattern = format!(
-            r"^(?:({})-)?(?:({})-)?(?:({})-)?({})(?:-(\d{{4}}-\d{{2}}-\d{{2}}))?$",
-            archs.join("|"), oses.join("|"), envs.join("|"), channels.join("|")
+            r"^({})(?:-(\d{{4}}-\d{{2}}-\d{{2}}))?(?:-({}))?(?:-({}))?(?:-({}))?$",
+            channels.join("|"), archs.join("|"), oses.join("|"), envs.join("|")
             );
 
         let re = Regex::new(&pattern).unwrap();
@@ -54,11 +54,11 @@ impl ToolchainDesc {
             }
 
             ToolchainDesc {
-                arch: c.at(1).and_then(fn_map),
-                os: c.at(2).and_then(fn_map),
-                env: c.at(3).and_then(fn_map),
-                channel: c.at(4).unwrap().to_owned(),
-                date: c.at(5).and_then(fn_map),
+                channel: c.at(1).unwrap().to_owned(),
+                date: c.at(2).and_then(fn_map),
+                arch: c.at(3).and_then(fn_map),
+                os: c.at(4).and_then(fn_map),
+                env: c.at(5).and_then(fn_map),
             }
         }).ok_or(Error::InvalidToolchainName(name.to_string()))
     }

--- a/src/multirust-dist/tests/dist.rs
+++ b/src/multirust-dist/tests/dist.rs
@@ -326,7 +326,7 @@ fn setup(edit: Option<&Fn(&str, &mut MockPackage)>,
     let ref temp_cfg = temp::Cfg::new(work_tempdir.path().to_owned(), temp::SharedNotifyHandler::none());
 
     let ref url = Url::parse(&format!("file://{}", dist_tempdir.path().to_string_lossy())).unwrap();
-    let ref toolchain = ToolchainDesc::from_str("x86_64-apple-darwin-nightly").unwrap();
+    let ref toolchain = ToolchainDesc::from_str("nightly-x86_64-apple-darwin").unwrap();
     let ref prefix = InstallPrefix::from(prefix_tempdir.path().to_owned());
 
     f(url, toolchain, prefix, temp_cfg);

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -653,3 +653,21 @@ fn subcommand_required_for_self() {
         assert!(out.status.code().unwrap() != 101);
     });
 }
+
+#[test]
+fn multi_host_smoke_test() {
+    // FIXME: Unfortunately the list of supported hosts is hard-coded,
+    // so we have to use the triple of a host we actually test on. That means
+    // that when we're testing on that host we can't test 'multi-host'.
+    let trip = this_host_triple();
+    if trip == clitools::MULTI_ARCH1 {
+        return;
+    }
+
+    clitools::setup(Scenario::MultiHost, &|config| {
+        let ref toolchain = format!("nightly-{}", clitools::MULTI_ARCH1);
+        expect_ok(config, &["rustup", "default", toolchain]);
+        expect_stdout_ok(config, &["rustc", "--version"],
+                         "xxxx-n-2"); // cross-host mocks have their own versions
+    });
+}


### PR DESCRIPTION
$channel-$date-$triple instead of $triple-$channel-$date. This
emphasizes that the channel is the most important information
here (it's the only thing that's required). Putting the
component of the name with potentially unbounded values at the end
makes parsing potentially saner over the long term, makes it
simpler in the future to parse toolchains without hard-coding
the exact architectures supported.

I added one smoke test for multi-host installs, but it needs a lot more attention still.

r? @Diggsey 