### PR TITLE
Use more bold and less cyan

### DIFF
--- a/src/multirust-cli/common.rs
+++ b/src/multirust-cli/common.rs
@@ -143,9 +143,9 @@ fn show_channel_updates(cfg: &Cfg, toolchains: Vec<(String, Result<UpdateStatus>
         let padding: String = iter::repeat(' ').take(padding).collect();
         let _ = write!(t, "  {}", padding);
         let _ = t.fg(color);
-        let _ = write!(t, "{}", banner);
+        let _ = write!(t, "{}:", banner);
         let _ = t.reset();
-        let _ = writeln!(t, ": {}", version);
+        let _ = writeln!(t, " {}", version);
     }
     let _ = writeln!(t, "");
 

--- a/src/multirust-cli/log.rs
+++ b/src/multirust-cli/log.rs
@@ -19,6 +19,7 @@ macro_rules! verbose {
 pub fn warn_fmt(args: fmt::Arguments) {
     let mut t = term2::stderr();
     let _ = t.fg(term2::color::BRIGHT_YELLOW);
+    let _ = t.attr(term2::Attr::Bold);
     let _ = write!(t, "warning: ");
     let _ = t.reset();
     let _ = t.write_fmt(args);
@@ -28,6 +29,7 @@ pub fn warn_fmt(args: fmt::Arguments) {
 pub fn err_fmt(args: fmt::Arguments) {
     let mut t = term2::stderr();
     let _ = t.fg(term2::color::BRIGHT_RED);
+    let _ = t.attr(term2::Attr::Bold);
     let _ = write!(t, "error: ");
     let _ = t.reset();
     let _ = t.write_fmt(args);
@@ -36,7 +38,7 @@ pub fn err_fmt(args: fmt::Arguments) {
 
 pub fn info_fmt(args: fmt::Arguments) {
     let mut t = term2::stderr();
-    let _ = t.fg(term2::color::BRIGHT_CYAN);
+    let _ = t.attr(term2::Attr::Bold);
     let _ = write!(t, "info: ");
     let _ = t.reset();
     let _ = t.write_fmt(args);
@@ -46,6 +48,7 @@ pub fn info_fmt(args: fmt::Arguments) {
 pub fn verbose_fmt(args: fmt::Arguments) {
     let mut t = term2::stderr();
     let _ = t.fg(term2::color::BRIGHT_MAGENTA);
+    let _ = t.attr(term2::Attr::Bold);
     let _ = write!(t, "verbose: ");
     let _ = t.reset();
     let _ = t.write_fmt(args);

--- a/src/multirust-cli/log.rs
+++ b/src/multirust-cli/log.rs
@@ -19,9 +19,8 @@ macro_rules! verbose {
 pub fn warn_fmt(args: fmt::Arguments) {
     let mut t = term2::stderr();
     let _ = t.fg(term2::color::BRIGHT_YELLOW);
-    let _ = write!(t, "warning");
+    let _ = write!(t, "warning: ");
     let _ = t.reset();
-    let _ = write!(t, ": ");
     let _ = t.write_fmt(args);
     let _ = write!(t, "\n");
 }
@@ -29,9 +28,8 @@ pub fn warn_fmt(args: fmt::Arguments) {
 pub fn err_fmt(args: fmt::Arguments) {
     let mut t = term2::stderr();
     let _ = t.fg(term2::color::BRIGHT_RED);
-    let _ = write!(t, "error");
+    let _ = write!(t, "error: ");
     let _ = t.reset();
-    let _ = write!(t, ": ");
     let _ = t.write_fmt(args);
     let _ = write!(t, "\n");
 }
@@ -39,9 +37,8 @@ pub fn err_fmt(args: fmt::Arguments) {
 pub fn info_fmt(args: fmt::Arguments) {
     let mut t = term2::stderr();
     let _ = t.fg(term2::color::BRIGHT_CYAN);
-    let _ = write!(t, "info");
+    let _ = write!(t, "info: ");
     let _ = t.reset();
-    let _ = write!(t, ": ");
     let _ = t.write_fmt(args);
     let _ = write!(t, "\n");
 }
@@ -49,9 +46,8 @@ pub fn info_fmt(args: fmt::Arguments) {
 pub fn verbose_fmt(args: fmt::Arguments) {
     let mut t = term2::stderr();
     let _ = t.fg(term2::color::BRIGHT_MAGENTA);
-    let _ = write!(t, "verbose");
+    let _ = write!(t, "verbose: ");
     let _ = t.reset();
-    let _ = write!(t, ": ");
     let _ = t.write_fmt(args);
     let _ = write!(t, "\n");
 }

--- a/src/multirust-cli/term2.rs
+++ b/src/multirust-cli/term2.rs
@@ -7,6 +7,7 @@ use term;
 use tty;
 
 pub use term::color;
+pub use term::Attr;
 
 pub fn stdout() -> StdoutTerminal {
     StdoutTerminal(term::stdout())
@@ -70,6 +71,16 @@ impl StdoutTerminal {
         }
     }
 
+    pub fn attr(&mut self, attr: Attr) -> Result<(), term::Error> {
+        if !tty::stderr_isatty() { return Ok(()) }
+
+        if let Some(ref mut t) = self.0 {
+            t.attr(attr)
+        } else {
+            Ok(())
+        }
+    }
+
     pub fn reset(&mut self) -> Result<(), term::Error> {
         if !tty::stderr_isatty() { return Ok(()) }
 
@@ -87,6 +98,16 @@ impl StderrTerminal {
 
         if let Some(ref mut t) = self.0 {
             t.fg(color)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn attr(&mut self, attr: Attr) -> Result<(), term::Error> {
+        if !tty::stderr_isatty() { return Ok(()) }
+
+        if let Some(ref mut t) = self.0 {
+            t.attr(attr)
         } else {
             Ok(())
         }

--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -19,7 +19,7 @@ fn update() {
     setup(&|config| {
         expect_ok_ex(config, &["multirust", "update", "nightly"],
 r"
-  nightly installed: 1.3.0 (hash-n-2)
+  nightly installed - 1.3.0 (hash-n-2)
 
 ",
 r"info: syncing channel updates for 'nightly'
@@ -41,7 +41,7 @@ fn update_again() {
         expect_ok(config, &["multirust", "update", "nightly"]);
         expect_ok_ex(config, &["multirust", "update", "nightly"],
 r"
-  nightly unchanged: 1.3.0 (hash-n-2)
+  nightly unchanged - 1.3.0 (hash-n-2)
 
 ",
 r"info: syncing channel updates for 'nightly'
@@ -54,7 +54,7 @@ fn default() {
     setup(&|config| {
         expect_ok_ex(config, &["multirust", "default", "nightly"],
 r"
-  nightly installed: 1.3.0 (hash-n-2)
+  nightly installed - 1.3.0 (hash-n-2)
 
 ",
 r"info: syncing channel updates for 'nightly'
@@ -78,7 +78,7 @@ fn override_again() {
         expect_ok(config, &["multirust", "override", "nightly"]);
         expect_ok_ex(config, &["multirust", "override", "nightly"],
 r"
-  nightly unchanged: 1.3.0 (hash-n-2)
+  nightly unchanged - 1.3.0 (hash-n-2)
 
 ",
 &format!(

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -583,7 +583,7 @@ fn update_all_no_update_whitespace() {
     setup(&|config| {
         expect_stdout_ok(config, &["multirust", "update", "nightly"],
 r"
-  nightly installed: 1.3.0 (hash-n-2)
+  nightly installed - 1.3.0 (hash-n-2)
 
 ");
     });

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -25,7 +25,7 @@ fn rustup_stable() {
         set_current_dist_date(config, "2015-01-02");
         expect_ok_ex(config, &["rustup", "--no-self-update"],
 r"
-  stable updated: 1.1.0 (hash-s-2)
+  stable updated - 1.1.0 (hash-s-2)
 
 ",
 r"info: syncing channel updates for 'stable'
@@ -48,7 +48,7 @@ fn rustup_stable_no_change() {
         expect_ok(config, &["rustup", "update", "stable"]);
         expect_ok_ex(config, &["rustup", "--no-self-update"],
 r"
-  stable unchanged: 1.0.0 (hash-s-1)
+  stable unchanged - 1.0.0 (hash-s-1)
 
 ",
 r"info: syncing channel updates for 'stable'
@@ -66,9 +66,9 @@ fn rustup_all_channels() {
         set_current_dist_date(config, "2015-01-02");
         expect_ok_ex(config, &["rustup", "--no-self-update"],
 r"
-   stable updated: 1.1.0 (hash-s-2)
-     beta updated: 1.2.0 (hash-b-2)
-  nightly updated: 1.3.0 (hash-n-2)
+   stable updated - 1.1.0 (hash-s-2)
+     beta updated - 1.2.0 (hash-b-2)
+  nightly updated - 1.3.0 (hash-n-2)
 
 ",
 r"info: syncing channel updates for 'stable'
@@ -113,9 +113,9 @@ fn rustup_some_channels_up_to_date() {
         expect_ok(config, &["multirust", "update", "beta"]);
         expect_ok_ex(config, &["rustup", "--no-self-update"],
 r"
-   stable updated: 1.1.0 (hash-s-2)
-   beta unchanged: 1.2.0 (hash-b-2)
-  nightly updated: 1.3.0 (hash-n-2)
+   stable updated - 1.1.0 (hash-s-2)
+   beta unchanged - 1.2.0 (hash-b-2)
+  nightly updated - 1.3.0 (hash-n-2)
 
 ",
 r"info: syncing channel updates for 'stable'
@@ -158,7 +158,7 @@ fn default() {
     setup(&|config| {
         expect_ok_ex(config, &["rustup", "default", "nightly"],
 r"
-  nightly installed: 1.3.0 (hash-n-2)
+  nightly installed - 1.3.0 (hash-n-2)
 
 ",
 r"info: syncing channel updates for 'nightly'
@@ -246,6 +246,7 @@ r"");
 }
 
 #[test]
+#[ignore(windows)] // FIXME rustup displays UNC paths
 fn show_toolchain_override() {
     setup(&|config| {
         let cwd = ::std::env::current_dir().unwrap();

--- a/tests/cli-self-update.rs
+++ b/tests/cli-self-update.rs
@@ -691,7 +691,7 @@ fn rustup_self_update_exact() {
 
         expect_ok_ex(config, &["rustup"],
 r"
-  stable unchanged: 1.1.0 (hash-s-2)
+  stable unchanged - 1.1.0 (hash-s-2)
 
 ",
 r"info: syncing channel updates for 'stable'
@@ -769,7 +769,7 @@ fn first_install_exact() {
     setup(&|config| {
         expect_ok_ex(config, &["rustup-setup", "-y"],
 r"
-  stable installed: 1.1.0 (hash-s-2)
+  stable installed - 1.1.0 (hash-s-2)
 
 ",
 r"info: syncing channel updates for 'stable'


### PR DESCRIPTION
Log headers are displayed in bold. Info-level logs are now just
bold white, not cyan.

The upgrade status is also bold, and not cyan.