### PR TITLE
More informative infos for target installation

### DIFF
--- a/src/multirust-dist/src/errors.rs
+++ b/src/multirust-dist/src/errors.rs
@@ -24,8 +24,8 @@ pub enum Notification<'a> {
     ExtensionNotInstalled(&'a Component),
     NonFatalError(&'a Error),
     MissingInstalledComponent(&'a str),
-    DownloadingComponent(&'a str),
-    InstallingComponent(&'a str),
+    DownloadingComponent(&'a str, &'a str, &'a str),
+    InstallingComponent(&'a str, &'a str, &'a str),
     DownloadingManifest(&'a str),
     DownloadingLegacyManifest,
 }
@@ -101,8 +101,8 @@ impl<'a> Notification<'a> {
             ChecksumValid(_) | NoUpdateHash(_) |
             DownloadingLegacyManifest  => NotificationLevel::Verbose,
             Extracting(_, _) | SignatureValid(_)  |
-            DownloadingComponent(_) |
-            InstallingComponent(_) |
+            DownloadingComponent(_, _, _) |
+            InstallingComponent(_, _, _) |
             ComponentAlreadyInstalled(_)  |
             RollingBack | DownloadingManifest(_) => NotificationLevel::Info,
             CantReadUpdateHash(_) | ExtensionNotInstalled(_) |
@@ -137,8 +137,20 @@ impl<'a> Display for Notification<'a> {
             }
             NonFatalError(e) => write!(f, "{}", e),
             MissingInstalledComponent(c) => write!(f, "during uninstall component {} was not found", c),
-            DownloadingComponent(c) => write!(f, "downloading component '{}'", c),
-            InstallingComponent(c) => write!(f, "installing component '{}'", c),
+            DownloadingComponent(c, h, t) => {
+                if h == t {
+                    write!(f, "downloading component '{}'", c)
+                } else {
+                    write!(f, "downloading component '{}' for '{}'", c, t)
+                }
+            }
+            InstallingComponent(c, h, t) => {
+                if h == t {
+                    write!(f, "installing component '{}'", c)
+                } else {
+                    write!(f, "installing component '{}' for '{}'", c, t)
+                }
+            }
             DownloadingManifest(t) => write!(f, "syncing channel updates for '{}'", t),
             DownloadingLegacyManifest => write!(f, "manifest not found. trying legacy manifest"),
         }

--- a/src/multirust-dist/src/manifestation.rs
+++ b/src/multirust-dist/src/manifestation.rs
@@ -126,7 +126,9 @@ impl Manifestation {
         let mut things_to_install: Vec<(Component, temp::File)> = Vec::new();
         for (component, url, hash) in components_urls_and_hashes {
 
-            notify_handler.call(Notification::DownloadingComponent(&component.pkg));
+            notify_handler.call(Notification::DownloadingComponent(&component.pkg,
+                                                                   &self.target_triple,
+                                                                   &component.target));
 
             // Download each package to temp file
             let temp_file = try!(temp_cfg.new_file());
@@ -170,7 +172,9 @@ impl Manifestation {
         // Install components
         for (component, installer_file) in things_to_install {
 
-            notify_handler.call(Notification::InstallingComponent(&component.pkg));
+            notify_handler.call(Notification::InstallingComponent(&component.pkg,
+                                                                  &self.target_triple,
+                                                                  &component.target));
 
             let package = try!(TarGzPackage::new_file(&installer_file, temp_cfg));
 
@@ -297,7 +301,9 @@ impl Manifestation {
         }
         let url = url.unwrap();
 
-        notify_handler.call(Notification::DownloadingComponent("rust"));
+        notify_handler.call(Notification::DownloadingComponent("rust",
+                                                               &self.target_triple,
+                                                               &self.target_triple));
 
         let dlcfg = DownloadCfg {
             dist_root: "bogus",
@@ -313,7 +319,9 @@ impl Manifestation {
 
         let prefix = self.installation.prefix();
 
-        notify_handler.call(Notification::InstallingComponent("rust"));
+        notify_handler.call(Notification::InstallingComponent("rust",
+                                                              &self.target_triple,
+                                                              &self.target_triple));
 
         // Begin transaction
         let mut tx = Transaction::new(prefix.clone(), temp_cfg, notify_handler);

--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -176,3 +176,15 @@ fn list_targets() {
 r"");
     });
 }
+
+#[test]
+fn cross_install_indicates_target() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        expect_ok_ex(config, &["rustup", "target", "add", clitools::CROSS_ARCH1],
+r"",
+&format!(r"info: downloading component 'rust-std' for '{0}'
+info: installing component 'rust-std' for '{0}'
+", clitools::CROSS_ARCH1));
+    });
+}


### PR DESCRIPTION
When installing cross-target packages, indicate the target triple
in the download and installation notifications.