### PR TITLE
Use raw::remove_dir instead of fs::remove_dir_all in test

### DIFF
--- a/tests/cli-self-update.rs
+++ b/tests/cli-self-update.rs
@@ -195,7 +195,7 @@ fn uninstall_deletes_multirust_home() {
 fn uninstall_works_if_multirust_home_doesnt_exist() {
     setup(&|config| {
         expect_ok(config, &["rustup-setup", "-y"]);
-        fs::remove_dir_all(&config.rustupdir).unwrap();
+        raw::remove_dir(&config.rustupdir).unwrap();
         expect_ok(config, &["multirust", "self", "uninstall", "-y"]);
     });
 }


### PR DESCRIPTION
Sholud fix the flakiness on the bots, but I haven't actually
been able to reproduce locally.

Probably fixes https://github.com/rust-lang-nursery/multirust-rs/issues/195