### PR TITLE
When an error occurs during install on windows, wait for keypress

### DIFF
--- a/src/multirust-cli/self_update.rs
+++ b/src/multirust-cli/self_update.rs
@@ -170,15 +170,35 @@ pub fn install(no_prompt: bool, verbose: bool) -> Result<()> {
         }
     }
 
-    try!(cleanup_legacy());
-    try!(install_bins());
-    try!(do_add_to_path(&get_add_path_methods()));
-    try!(maybe_install_rust_stable(verbose));
+    let install_res: Result<()> = (|| {
+        try!(cleanup_legacy());
+        try!(install_bins());
+        try!(do_add_to_path(&get_add_path_methods()));
+        try!(maybe_install_rust_stable(verbose));
 
-    if cfg!(unix) {
-        let ref env_file = try!(utils::cargo_home()).join("env");
-        let ref env_str = try!(shell_export_string());
-        try!(utils::write_file("env", env_file, env_str));
+        if cfg!(unix) {
+            let ref env_file = try!(utils::cargo_home()).join("env");
+            let ref env_str = try!(shell_export_string());
+            try!(utils::write_file("env", env_file, env_str));
+        }
+
+        Ok(())
+    })();
+
+    if let Err(e) = install_res {
+        err!("{}", e);
+
+        // On windows, where installation happens in a console
+        // that may have opened just for this purpose, give
+        // the user an opportunity to see the error before the
+        // window closes.
+        if cfg!(windows) && !no_prompt {
+            println!("");
+            println!("Press any key to continue");
+            try!(common::wait_for_keypress());
+        }
+
+        process::exit(1);
     }
 
     // More helpful advice, skip if -y


### PR DESCRIPTION
Since this happens in a fresh console window the error won't be seen
unless the program waits for input.

Fixes #181