### PR TITLE
On windows install, ask to press enter to continue

### DIFF
--- a/src/multirust-cli/common.rs
+++ b/src/multirust-cli/common.rs
@@ -28,20 +28,11 @@ pub fn confirm(question: &str, default: bool) -> Result<bool> {
     Ok(r)
 }
 
-fn read_line() -> Result<String> {
+pub fn read_line() -> Result<String> {
     let stdin = std::io::stdin();
     let stdin = stdin.lock();
     let mut lines = stdin.lines();
     lines.next().and_then(|l| l.ok()).ok_or(Error::ReadStdin)
-}
-
-pub fn wait_for_keypress() -> Result<()> {
-    let stdin = std::io::stdin();
-    if stdin.bytes().next().is_some() {
-        Ok(())
-    } else {
-        Err(Error::ReadStdin)
-    }
 }
 
 pub fn set_globals(verbose: bool) -> Result<Cfg> {

--- a/src/multirust-cli/self_update.rs
+++ b/src/multirust-cli/self_update.rs
@@ -170,15 +170,35 @@ pub fn install(no_prompt: bool, verbose: bool) -> Result<()> {
         }
     }
 
-    try!(cleanup_legacy());
-    try!(install_bins());
-    try!(do_add_to_path(&get_add_path_methods()));
-    try!(maybe_install_rust_stable(verbose));
+    let install_res: Result<()> = (|| {
+        try!(cleanup_legacy());
+        try!(install_bins());
+        try!(do_add_to_path(&get_add_path_methods()));
+        try!(maybe_install_rust_stable(verbose));
 
-    if cfg!(unix) {
-        let ref env_file = try!(utils::cargo_home()).join("env");
-        let ref env_str = try!(shell_export_string());
-        try!(utils::write_file("env", env_file, env_str));
+        if cfg!(unix) {
+            let ref env_file = try!(utils::cargo_home()).join("env");
+            let ref env_str = try!(shell_export_string());
+            try!(utils::write_file("env", env_file, env_str));
+        }
+
+        Ok(())
+    })();
+
+    if let Err(e) = install_res {
+        err!("{}", e);
+
+        // On windows, where installation happens in a console
+        // that may have opened just for this purpose, give
+        // the user an opportunity to see the error before the
+        // window closes.
+        if cfg!(windows) && !no_prompt {
+            println!("");
+            println!("Press any key to continue");
+            try!(common::wait_for_keypress());
+        }
+
+        process::exit(1);
     }
 
     // More helpful advice, skip if -y

--- a/src/multirust-cli/self_update.rs
+++ b/src/multirust-cli/self_update.rs
@@ -194,8 +194,8 @@ pub fn install(no_prompt: bool, verbose: bool) -> Result<()> {
         // window closes.
         if cfg!(windows) && !no_prompt {
             println!("");
-            println!("Press any key to continue");
-            try!(common::wait_for_keypress());
+            println!("Press enter to continue");
+            try!(common::read_line());
         }
 
         process::exit(1);
@@ -216,8 +216,8 @@ pub fn install(no_prompt: bool, verbose: bool) -> Result<()> {
         // the user to press a key to continue.
         if cfg!(windows) {
             println!("");
-            println!("Press any key to continue");
-            try!(common::wait_for_keypress());
+            println!("Press enter to continue");
+            try!(common::read_line());
         }
     }
 


### PR DESCRIPTION

The wait_for_keypress method actually reads a whole line
for reasons I don't understand, so just change the UI
to ask for enter instead.

Supercedes https://github.com/rust-lang-nursery/multirust-rs/pull/231