### PR TITLE
Formatting `rustup override list`

### DIFF
--- a/src/multirust-cli/common.rs
+++ b/src/multirust-cli/common.rs
@@ -8,6 +8,7 @@ use std::ffi::OsStr;
 use std::io::{Write, Read, BufRead};
 use std::process::{self, Command};
 use std::{cmp, iter};
+use std::str::FromStr;
 use std;
 use term2;
 
@@ -282,12 +283,24 @@ pub fn list_overrides(cfg: &Cfg) -> Result<()> {
         println!("no overrides");
     } else {
         for o in overrides {
-            println!("{}", o);
+            split_override::<String>(&o, ';').map(|li| 
+                println!("{:<40}\t{:<20}", li.0, li.1)
+            );
         }
     }
     Ok(())
 }
 
+
 pub fn version() -> &'static str {
     option_env!("CARGO_PKG_VERSION").unwrap_or("unknown")
+}
+
+fn split_override<T: FromStr>(s: &str, separator: char) -> Option<(T, T)> {
+    s.find(separator).and_then(|index| {
+        match (T::from_str(&s[..index]), T::from_str(&s[index + 1..])) {
+            (Ok(l), Ok(r)) => Some((l, r)),
+            _ => None
+        }
+    })
 }

--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -114,6 +114,17 @@ r"",
 }
 
 #[test]
+fn list_overrides() {
+    setup(&|config| {
+        let cwd = std::fs::canonicalize(env::current_dir().unwrap()).unwrap();
+        let trip = this_host_triple();
+        expect_ok(config, &["rustup", "override", "add", "nightly"]);
+        expect_ok_ex(config, &["rustup", "override", "list"], 
+                     &format!("{:<40}\t{:<20}\n", cwd.display(), &format!("nightly-{}", trip)), r""); 
+    });
+}
+
+#[test]
 fn update_no_manifest() {
     setup(&|config| {
         expect_err_ex(config, &["rustup", "update", "nightly-2016-01-01"],


### PR DESCRIPTION
Sample output.

```
\\?\D:\src\peschkaj\coreutils                   nightly-x86_64-msvc
\\?\D:\src\peschkaj\flaker                      nightly-x86_64-msvc
\\?\D:\src\peschkaj\multirust-rs                nightly-x86_64-msvc
\\?\D:\src\peschkaj\todo                        nightly-x86_64-msvc
\\?\D:\src\test-rustup                          stable-msvc
```

UNC paths will be cleaned up in https://github.com/rust-lang-nursery/multirust-rs/issues/235