### PR TITLE
Allow host triple to be configured independently of the build triple

### DIFF
--- a/src/multirust-cli/self_update.rs
+++ b/src/multirust-cli/self_update.rs
@@ -481,7 +481,7 @@ fn delete_multirust_and_cargo_home() -> Result<()> {
 
         try!(Command::new(gc_exe).spawn()
              .map_err(|e| Error::WindowsUninstallMadness(e)));
-        
+
         // The catch 22 article says we must sleep here to give
         // Windows a chance to bump the processes file reference
         // count. acrichto though is in disbelief and *demanded* that
@@ -817,7 +817,7 @@ pub fn prepare_update() -> Result<Option<PathBuf>> {
     }
 
     // Get host triple
-    let triple = dist::get_host_triple();
+    let triple = dist::TargetTriple::from_host();
 
     let update_root = env::var("RUSTUP_UPDATE_ROOT")
         .unwrap_or(String::from(UPDATE_ROOT));

--- a/src/multirust-mock/src/clitools.rs
+++ b/src/multirust-mock/src/clitools.rs
@@ -391,21 +391,25 @@ fn build_mock_channel(s: Scenario, channel: &str, date: &str,
 }
 
 pub fn this_host_triple() -> String {
-    let arch = if cfg!(target_arch = "x86") { "i686" }
-    else if cfg!(target_arch = "x86_64") { "x86_64" }
-    else { unimplemented!() };
-    let os = if cfg!(target_os = "linux") { "unknown-linux" }
-    else if cfg!(target_os = "windows") { "pc-windows" }
-    else if cfg!(target_os = "macos") { "apple-darwin" }
-    else { unimplemented!() };
-    let env = if cfg!(target_env = "gnu") { Some("gnu") }
-    else if cfg!(target_env = "msvc") { Some("msvc") }
-    else { None };
-
-    if let Some(env) = env {
-        format!("{}-{}-{}", arch, os, env)
+    if let Some(triple) = option_env!("RUSTUP_OVERRIDE_HOST_TRIPLE") {
+        triple.to_owned()
     } else {
-        format!("{}-{}", arch, os)
+        let arch = if cfg!(target_arch = "x86") { "i686" }
+        else if cfg!(target_arch = "x86_64") { "x86_64" }
+        else { unimplemented!() };
+        let os = if cfg!(target_os = "linux") { "unknown-linux" }
+        else if cfg!(target_os = "windows") { "pc-windows" }
+        else if cfg!(target_os = "macos") { "apple-darwin" }
+        else { unimplemented!() };
+        let env = if cfg!(target_env = "gnu") { Some("gnu") }
+        else if cfg!(target_env = "msvc") { Some("msvc") }
+        else { None };
+
+        if let Some(env) = env {
+            format!("{}-{}-{}", arch, os, env)
+        } else {
+            format!("{}-{}", arch, os)
+        }
     }
 }
 


### PR DESCRIPTION
This allows setting the `RUSTUP_OVERRIDE_HOST_TRIPLE` environment variable at build time to set a different host triple from the build triple.

This will allow us to release versions of rustup which use 64-bit or msvc toolchains by default, even if rustup itself was compiled for 32-bit gnu.