### PR TITLE
Make `TargetTriple` a newtype String

### DIFF
--- a/src/multirust-cli/multirust_mode.rs
+++ b/src/multirust-cli/multirust_mode.rs
@@ -324,7 +324,7 @@ fn add_target(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
     let toolchain = try!(cfg.get_toolchain(toolchain, false));
     let new_component = Component {
         pkg: "rust-std".to_string(),
-        target: try!(TargetTriple::from_str(target)),
+        target: TargetTriple::from_str(target),
     };
     try!(toolchain.add_component(new_component));
 
@@ -337,7 +337,7 @@ fn remove_target(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
     let toolchain = try!(cfg.get_toolchain(toolchain, false));
     let new_component = Component {
         pkg: "rust-std".to_string(),
-        target: try!(TargetTriple::from_str(target)),
+        target: TargetTriple::from_str(target),
     };
     try!(toolchain.remove_component(new_component));
 

--- a/src/multirust-cli/rustup_mode.rs
+++ b/src/multirust-cli/rustup_mode.rs
@@ -274,7 +274,7 @@ fn target_add(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
     let target = m.value_of("target").expect("");
     let new_component = Component {
         pkg: "rust-std".to_string(),
-        target: try!(TargetTriple::from_str(target)),
+        target: TargetTriple::from_str(target),
     };
 
     toolchain.add_component(new_component)
@@ -285,7 +285,7 @@ fn target_remove(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
     let target = m.value_of("target").expect("");
     let new_component = Component {
         pkg: "rust-std".to_string(),
-        target: try!(TargetTriple::from_str(target)),
+        target: TargetTriple::from_str(target),
     };
 
     toolchain.remove_component(new_component)

--- a/src/multirust-dist/src/dist.rs
+++ b/src/multirust-dist/src/dist.rs
@@ -19,6 +19,11 @@ use itertools::Itertools;
 pub const DEFAULT_DIST_ROOT: &'static str = "https://static.rust-lang.org/dist";
 pub const UPDATE_HASH_LEN: usize = 20;
 
+// A toolchain descriptor from rustup's perspective. These contain
+// 'partial target triples', which allow toolchain names like
+// 'stable-msvc' to work. Partial target triples though are parsed
+// from a hardcoded set of known triples, whereas target triples
+// are nearly-arbitrary strings.
 #[derive(Debug, Clone)]
 pub struct PartialToolchainDesc {
     // Either "nightly", "stable", "beta", or an explicit version number
@@ -34,13 +39,9 @@ pub struct PartialTargetTriple {
     pub env: Option<String>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct TargetTriple {
-    pub arch: String,
-    pub os: String,
-    pub env: Option<String>,
-}
-
+// Fully-resolved toolchain descriptors. These always have full target
+// triples attached to them and are used for canonical identification,
+// such as naming their installation directory.
 #[derive(Debug, Clone)]
 pub struct ToolchainDesc {
     // Either "nightly", "stable", "beta", or an explicit version number
@@ -48,6 +49,12 @@ pub struct ToolchainDesc {
     pub date: Option<String>,
     pub target: TargetTriple,
 }
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct TargetTriple(String);
+
+// These lists contain the targets known to rustup, and used to build
+// the PartialTargetTriple.
 
 static LIST_ARCHS: &'static [&'static str] = &[
     "i386", "i586", "i686", "x86_64", "arm", "armv7", "armv7s", "aarch64", "mips", "mipsel",
@@ -62,39 +69,19 @@ static LIST_ENVS: &'static [&'static str] = &[
 ];
 
 impl TargetTriple {
-    pub fn from_str(name: &str) -> Result<Self> {
-        let pattern = format!(
-            r"^({})-({})(?:-({}))?$",
-            LIST_ARCHS.join("|"), LIST_OSES.join("|"), LIST_ENVS.join("|")
-            );
-        let re = Regex::new(&pattern).unwrap();
-        re.captures(name).map(|c| {
-            fn fn_map(s: &str) -> Option<String> {
-                if s == "" {
-                    None
-                } else {
-                    Some(s.to_owned())
-                }
-            }
-
-            TargetTriple {
-                arch: c.at(1).unwrap().to_owned(),
-                os: c.at(2).unwrap().to_owned(),
-                env: c.at(3).and_then(fn_map),
-            }
-        }).ok_or(Error::InvalidTargetTriple(name.to_string()))
+    pub fn from_str(name: &str) -> Self {
+        TargetTriple(name.to_string())
     }
 
     pub fn from_host() -> Self {
         if let Some(triple) = option_env!("RUSTUP_OVERRIDE_HOST_TRIPLE") {
-            // Unwrap here because it's a compile-time constant
-            TargetTriple::from_str(triple).unwrap()
+            TargetTriple::from_str(triple)
         } else {
             let (arch, os, env) = get_original_host_triple();
-            TargetTriple {
-                arch: arch.to_owned(),
-                os: os.to_owned(),
-                env: env.map(ToOwned::to_owned)
+            if let Some(env) = env {
+                TargetTriple(format!("{}-{}-{}", arch, os ,env))
+            } else {
+                TargetTriple(format!("{}-{}", arch, os))
             }
         }
     }
@@ -177,22 +164,32 @@ impl PartialToolchainDesc {
     }
 
     pub fn resolve(self, host: &TargetTriple) -> ToolchainDesc {
+        let host = PartialTargetTriple::from_str(&host.0)
+            .expect("host triple couldn't be converted to partial triple");
+        let host_arch = host.arch.expect("");
+        let host_os = host.os.expect("");
+        let host_env = host.env;
+
         // If OS was specified, don't default to host environment, even if the OS matches
         // the host OS, otherwise cannot specify no environment.
         let env = if self.target.os.is_some() {
             self.target.env
         } else {
-            self.target.env.or_else(|| host.env.clone())
+            self.target.env.or_else(|| host_env)
         };
-        let os = self.target.os.unwrap_or_else(|| host.os.clone());
+        let arch = self.target.arch.unwrap_or_else(|| host_arch);
+        let os = self.target.os.unwrap_or_else(|| host_os);
+
+        let trip = if let Some(env) = env {
+            format!("{}-{}-{}", arch, os, env)
+        } else {
+            format!("{}-{}", arch, os)
+        };
+
         ToolchainDesc {
             channel: self.channel,
             date: self.date,
-            target: TargetTriple {
-                arch: self.target.arch.unwrap_or_else(|| host.arch.clone()),
-                os: os,
-                env: env
-            }
+            target: TargetTriple(trip),
         }
     }
 }
@@ -204,8 +201,8 @@ impl ToolchainDesc {
                         r"\d{1}\.\d{2}\.\d{1}"];
 
         let pattern = format!(
-            r"^({})(?:-(\d{{4}}-\d{{2}}-\d{{2}}))?-({})-({})(?:-({}))?$",
-            channels.join("|"), LIST_ARCHS.join("|"), LIST_OSES.join("|"), LIST_ENVS.join("|")
+            r"^({})(?:-(\d{{4}}-\d{{2}}-\d{{2}}))?-(.*)?$",
+            channels.join("|"),
             );
 
         let re = Regex::new(&pattern).unwrap();
@@ -221,11 +218,7 @@ impl ToolchainDesc {
             ToolchainDesc {
                 channel: c.at(1).unwrap().to_owned(),
                 date: c.at(2).and_then(fn_map),
-                target: TargetTriple {
-                    arch: c.at(3).unwrap().to_owned(),
-                    os: c.at(4).unwrap().to_owned(),
-                    env: c.at(5).and_then(fn_map)
-                }
+                target: TargetTriple(c.at(3).unwrap().to_owned()),
             }
         }).ok_or(Error::InvalidToolchainName(name.to_string()))
     }
@@ -290,11 +283,7 @@ impl<'a> Manifest<'a> {
 
 impl fmt::Display for TargetTriple {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if let Some(ref env) = self.env {
-            write!(f, "{}-{}-{}", self.arch, self.os, env)
-        } else {
-            write!(f, "{}-{}", self.arch, self.os)
-        }
+        self.0.fmt(f)
     }
 }
 

--- a/src/multirust-dist/src/manifest.rs
+++ b/src/multirust-dist/src/manifest.rs
@@ -150,7 +150,7 @@ impl Package {
 
         for (k, v) in target_table {
             if let toml::Value::Table(t) = v {
-                result.insert(try!(TargetTriple::from_str(&k)), try!(TargettedPackage::from_toml(t, &path)));
+                result.insert(TargetTriple::from_str(&k), try!(TargettedPackage::from_toml(t, &path)));
             }
         }
 
@@ -224,7 +224,7 @@ impl Component {
     pub fn from_toml(mut table: toml::Table, path: &str) -> Result<Self> {
         Ok(Component {
             pkg: try!(get_string(&mut table, "pkg", path)),
-            target: try!(get_string(&mut table, "target", path).and_then(|s| TargetTriple::from_str(&s))),
+            target: try!(get_string(&mut table, "target", path).map(|s| TargetTriple::from_str(&s))),
         })
     }
     pub fn to_toml(self) -> toml::Table {

--- a/src/multirust-dist/tests/dist.rs
+++ b/src/multirust-dist/tests/dist.rs
@@ -402,10 +402,10 @@ fn update_preserves_extensions() {
     setup(None, &|url, toolchain, prefix, temp_cfg| {
         let ref adds = vec![
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin")
             },
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-unknown-linux-gnu").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-unknown-linux-gnu")
             }
             ];
 
@@ -444,7 +444,7 @@ fn update_preserves_extensions_that_became_components() {
     setup(Some(edit), &|url, toolchain, prefix, temp_cfg| {
         let ref adds = vec![
             Component {
-                pkg: "bonus".to_string(), target: TargetTriple::from_str("x86_64-apple-darwin").unwrap()
+                pkg: "bonus".to_string(), target: TargetTriple::from_str("x86_64-apple-darwin")
             },
             ];
 
@@ -502,10 +502,10 @@ fn add_extensions_for_initial_install() {
     setup(None, &|url, toolchain, prefix, temp_cfg| {
         let ref adds = vec![
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin")
             },
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-unknown-linux-gnu").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-unknown-linux-gnu")
             }
             ];
 
@@ -522,10 +522,10 @@ fn add_extensions_for_same_manifest() {
 
         let ref adds = vec![
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin")
             },
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-unknown-linux-gnu").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-unknown-linux-gnu")
             }
             ];
 
@@ -547,10 +547,10 @@ fn add_extensions_for_upgrade() {
 
         let ref adds = vec![
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin")
             },
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-unknown-linux-gnu").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-unknown-linux-gnu")
             }
             ];
 
@@ -567,7 +567,7 @@ fn add_extension_not_in_manifest() {
     setup(None, &|url, toolchain, prefix, temp_cfg| {
         let ref adds = vec![
             Component {
-                pkg: "rust-bogus".to_string(), target: TargetTriple::from_str("i686-apple-darwin").unwrap()
+                pkg: "rust-bogus".to_string(), target: TargetTriple::from_str("i686-apple-darwin")
             },
             ];
 
@@ -581,7 +581,7 @@ fn add_extension_that_is_required_component() {
     setup(None, &|url, toolchain, prefix, temp_cfg| {
         let ref adds = vec![
             Component {
-                pkg: "rustc".to_string(), target: TargetTriple::from_str("x86_64-apple-darwin").unwrap()
+                pkg: "rustc".to_string(), target: TargetTriple::from_str("x86_64-apple-darwin")
             },
             ];
 
@@ -606,7 +606,7 @@ fn add_extensions_does_not_remove_other_components() {
 
         let ref adds = vec![
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin")
             },
             ];
 
@@ -623,7 +623,7 @@ fn remove_extensions_for_initial_install() {
     setup(None, &|url, toolchain, prefix, temp_cfg| {
         let ref removes = vec![
             Component {
-                pkg: "rustc".to_string(), target: TargetTriple::from_str("x86_64-apple-darwin").unwrap()
+                pkg: "rustc".to_string(), target: TargetTriple::from_str("x86_64-apple-darwin")
             },
             ];
 
@@ -636,10 +636,10 @@ fn remove_extensions_for_same_manifest() {
     setup(None, &|url, toolchain, prefix, temp_cfg| {
         let ref adds = vec![
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin")
             },
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-unknown-linux-gnu").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-unknown-linux-gnu")
             }
             ];
 
@@ -647,7 +647,7 @@ fn remove_extensions_for_same_manifest() {
 
         let ref removes = vec![
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin")
             },
             ];
 
@@ -665,10 +665,10 @@ fn remove_extensions_for_upgrade() {
 
         let ref adds = vec![
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin")
             },
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-unknown-linux-gnu").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-unknown-linux-gnu")
             }
             ];
 
@@ -678,7 +678,7 @@ fn remove_extensions_for_upgrade() {
 
         let ref removes = vec![
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin")
             },
             ];
 
@@ -701,7 +701,7 @@ fn remove_extension_not_in_manifest() {
 
         let ref removes = vec![
             Component {
-                pkg: "rust-bogus".to_string(), target: TargetTriple::from_str("i686-apple-darwin").unwrap()
+                pkg: "rust-bogus".to_string(), target: TargetTriple::from_str("i686-apple-darwin")
             },
             ];
 
@@ -729,7 +729,7 @@ fn remove_extension_not_in_manifest_but_is_already_installed() {
 
         let ref adds = vec![
             Component {
-                pkg: "bonus".to_string(), target: TargetTriple::from_str("x86_64-apple-darwin").unwrap()
+                pkg: "bonus".to_string(), target: TargetTriple::from_str("x86_64-apple-darwin")
             },
             ];
         update_from_dist(url, toolchain, prefix, adds, &[], temp_cfg, NotifyHandler::none()).unwrap();
@@ -739,7 +739,7 @@ fn remove_extension_not_in_manifest_but_is_already_installed() {
 
         let ref removes = vec![
             Component {
-                pkg: "bonus".to_string(), target: TargetTriple::from_str("x86_64-apple-darwin").unwrap()
+                pkg: "bonus".to_string(), target: TargetTriple::from_str("x86_64-apple-darwin")
             },
             ];
         update_from_dist(url, toolchain, prefix, &[], removes, temp_cfg, NotifyHandler::none()).unwrap();
@@ -754,7 +754,7 @@ fn remove_extension_that_is_required_component() {
 
         let ref removes = vec![
             Component {
-                pkg: "rustc".to_string(), target: TargetTriple::from_str("x86_64-apple-darwin").unwrap()
+                pkg: "rustc".to_string(), target: TargetTriple::from_str("x86_64-apple-darwin")
             },
             ];
 
@@ -770,7 +770,7 @@ fn remove_extension_not_installed() {
 
         let ref removes = vec![
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin")
             },
             ];
 
@@ -788,7 +788,7 @@ fn remove_extensions_does_not_remove_other_components() {
     setup(None, &|url, toolchain, prefix, temp_cfg| {
         let ref adds = vec![
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin")
             },
             ];
 
@@ -796,7 +796,7 @@ fn remove_extensions_does_not_remove_other_components() {
 
         let ref removes = vec![
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin")
             },
             ];
 
@@ -813,7 +813,7 @@ fn add_and_remove_for_upgrade() {
 
         let ref adds = vec![
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-unknown-linux-gnu").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-unknown-linux-gnu")
             },
             ];
 
@@ -823,13 +823,13 @@ fn add_and_remove_for_upgrade() {
 
         let ref adds = vec![
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin")
             },
             ];
 
         let ref removes = vec![
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-unknown-linux-gnu").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-unknown-linux-gnu")
             },
             ];
 
@@ -845,7 +845,7 @@ fn add_and_remove() {
     setup(None, &|url, toolchain, prefix, temp_cfg| {
         let ref adds = vec![
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-unknown-linux-gnu").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-unknown-linux-gnu")
             },
             ];
 
@@ -853,13 +853,13 @@ fn add_and_remove() {
 
         let ref adds = vec![
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin")
             },
             ];
 
         let ref removes = vec![
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-unknown-linux-gnu").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-unknown-linux-gnu")
             },
             ];
 
@@ -878,13 +878,13 @@ fn add_and_remove_same_component() {
 
         let ref adds = vec![
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple-darwin")
             },
             ];
 
         let ref removes = vec![
             Component {
-                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple_darwin").unwrap()
+                pkg: "rust-std".to_string(), target: TargetTriple::from_str("i686-apple_darwin")
             },
             ];
 

--- a/src/multirust-dist/tests/manifest.rs
+++ b/src/multirust-dist/tests/manifest.rs
@@ -11,8 +11,8 @@ static EXAMPLE2: &'static str = include_str!("channel-rust-nightly-example2.toml
 
 #[test]
 fn parse_smoke_test() {
-    let x86_64_unknown_linux_gnu = TargetTriple::from_str("x86_64-unknown-linux-gnu").unwrap();
-    let x86_64_unknown_linux_musl = TargetTriple::from_str("x86_64-unknown-linux-musl").unwrap();
+    let x86_64_unknown_linux_gnu = TargetTriple::from_str("x86_64-unknown-linux-gnu");
+    let x86_64_unknown_linux_musl = TargetTriple::from_str("x86_64-unknown-linux-musl");
 
     let pkg = Manifest::parse(EXAMPLE).unwrap();
 
@@ -87,4 +87,12 @@ date = "2015-10-10"
         Error::MissingPackageForComponent(_) => {},
         _ => panic!(),
     }
+}
+
+// #248
+#[test]
+fn manifest_can_contain_unknown_targets() {
+    let manifest = EXAMPLE.replace("x86_64-unknown-linux-gnu", "mycpu-myvendor-myos");
+
+    assert!(Manifest::parse(&manifest).is_ok());
 }

--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -141,7 +141,8 @@ fn update_invalid_toolchain() {
    setup(&|config| {
         expect_err_ex(config, &["rustup", "update", "nightly-2016-03-1"],
 r"",
-r"error: toolchain 'nightly-2016-03-1' is not installed
+r"info: syncing channel updates for 'nightly-2016-03-1'
+error: target not found: '2016-03-1'
 ");
    });
  }
@@ -151,7 +152,8 @@ fn default_invalid_toolchain() {
    setup(&|config| {
         expect_err_ex(config, &["rustup", "default", "nightly-2016-03-1"],
 r"",
-r"error: toolchain 'nightly-2016-03-1' is not installed
+r"info: syncing channel updates for 'nightly-2016-03-1'
+error: target not found: '2016-03-1'
 ");
    });
 }

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -531,7 +531,7 @@ fn add_target_bogus() {
     setup(&|config| {
         expect_ok(config, &["multirust", "default", "nightly"]);
         expect_err(config, &["multirust", "add-target", "nightly", "bogus"],
-                   "error: invalid target triple: 'bogus'");
+                   "does not contain component 'rust-std' for target 'bogus'");
     });
 }
 
@@ -615,7 +615,7 @@ fn remove_target_bogus() {
     setup(&|config| {
         expect_ok(config, &["multirust", "default", "nightly"]);
         expect_err(config, &["multirust", "remove-target", "nightly", "bogus"],
-                   "error: invalid target triple: 'bogus'");
+                   "does not contain component 'rust-std' for target 'bogus'");
     });
 }
 


### PR DESCRIPTION
Target triples are just arbitrary strings with some rough heuristics for parsing. The Rust build servers can send us builds for any target, not just those we know about, so we can't assume much about what they are. This patch converts `TargetTriple` to a simple newtype string so that parsing a manifest containing unknown triples works.

Fixes #248.

r? @Diggsey