### PR TITLE
Adds formatting to strip default UNC verbatim paths on Windows machines.

### DIFF
--- a/src/multirust-cli/common.rs
+++ b/src/multirust-cli/common.rs
@@ -284,7 +284,9 @@ pub fn list_overrides(cfg: &Cfg) -> Result<()> {
     } else {
         for o in overrides {
             split_override::<String>(&o, ';').map(|li| 
-                println!("{:<40}\t{:<20}", li.0, li.1)
+                println!("{:<40}\t{:<20}", 
+                         utils::format_path_for_display(&li.0), 
+                         li.1)
             );
         }
     }

--- a/src/multirust-utils/src/utils.rs
+++ b/src/multirust-utils/src/utils.rs
@@ -443,3 +443,12 @@ pub fn multirust_home() -> Result<PathBuf> {
     let user_home = home_dir().map(|p| p.join(".multirust"));
     multirust_home.or(user_home).ok_or(Error::MultirustHome)
 }
+
+pub fn format_path_for_display(path: &str) -> String {
+    let unc_present = path.find(r"\\?\");
+    
+    match unc_present {
+        None => path.to_owned(),
+        Some(_) => path[4..].to_owned(),
+    }
+}

--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -117,10 +117,16 @@ r"",
 fn list_overrides() {
     setup(&|config| {
         let cwd = std::fs::canonicalize(env::current_dir().unwrap()).unwrap();
+        let mut cwd_formatted = format!("{}", cwd.display()).to_string();
+        
+        if cfg!(windows) {
+            cwd_formatted = cwd_formatted[4..].to_owned();
+        }
+        
         let trip = this_host_triple();
         expect_ok(config, &["rustup", "override", "add", "nightly"]);
         expect_ok_ex(config, &["rustup", "override", "list"], 
-                     &format!("{:<40}\t{:<20}\n", cwd.display(), &format!("nightly-{}", trip)), r""); 
+                     &format!("{:<40}\t{:<20}\n", cwd_formatted, &format!("nightly-{}", trip)), r""); 
     });
 }
 


### PR DESCRIPTION
This should clean up output on Windows machines to remove default UNC verbatim path (`\\?`) on Windows machines. The UNC path will still be present if a rust override is set up a remote share since `util::format_path_for_display` only checks for the `\\?\` literal.