### PR TITLE
Use directory junctions directly on windows instead of symlinks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,6 @@ keywords = ["multirust", "install", "proxy"]
 
 license = "MIT OR Apache-2.0"
 
-[features]
-symlinks = []
-
 [dependencies]
 multirust-dist = { path = "src/multirust-dist" }
 multirust-utils = { path = "src/multirust-utils" }

--- a/src/multirust-utils/src/raw.rs
+++ b/src/multirust-utils/src/raw.rs
@@ -268,7 +268,7 @@ pub fn symlink_dir(src: &Path, dest: &Path) -> io::Result<()> {
     #[cfg(windows)]
     fn symlink_dir_inner(src: &Path, dest: &Path) -> io::Result<()> {
         // std's symlink uses Windows's symlink function, which requires
-        // admin. We can create a directory junctions the hard way without
+        // admin. We can create directory junctions the hard way without
         // though.
         symlink_junction_inner(src, dest)
     }

--- a/src/multirust-utils/src/raw.rs
+++ b/src/multirust-utils/src/raw.rs
@@ -278,20 +278,6 @@ pub fn symlink_dir(src: &Path, dest: &Path) -> io::Result<()> {
     symlink_dir_inner(src, dest)
 }
 
-pub fn symlink_file(src: &Path, dest: &Path) -> io::Result<()> {
-    #[cfg(windows)]
-    fn symlink_file_inner(src: &Path, dest: &Path) -> io::Result<()> {
-        ::std::os::windows::fs::symlink_file(src, dest)
-    }
-    #[cfg(not(windows))]
-    fn symlink_file_inner(src: &Path, dest: &Path) -> io::Result<()> {
-        ::std::os::unix::fs::symlink(src, dest)
-    }
-
-    let _ = fs::remove_file(dest);
-    symlink_file_inner(src, dest)
-}
-
 pub fn hardlink(src: &Path, dest: &Path) -> io::Result<()> {
     let _ = fs::remove_file(dest);
     fs::hard_link(src, dest)

--- a/src/multirust-utils/src/utils.rs
+++ b/src/multirust-utils/src/utils.rs
@@ -184,16 +184,6 @@ pub fn symlink_dir(src: &Path, dest: &Path, notify_handler: NotifyHandler) -> Re
     })
 }
 
-pub fn symlink_file(src: &Path, dest: &Path) -> Result<()> {
-    raw::symlink_file(src, dest).map_err(|e| {
-        Error::LinkingFile {
-            src: PathBuf::from(src),
-            dest: PathBuf::from(dest),
-            error: e,
-        }
-    })
-}
-
 pub fn hardlink_file(src: &Path, dest: &Path) -> Result<()> {
     raw::hardlink(src, dest).map_err(|e| {
         Error::LinkingFile {

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -41,7 +41,6 @@ fn rustc_with_bad_multirust_toolchain_env_var() {
     });
 }
 
-#[cfg_attr(all(not(feature="symlinks"), windows), ignore)]
 #[test]
 fn install_toolchain_linking_from_path() {
     setup(&|config| {
@@ -66,7 +65,6 @@ fn install_toolchain_from_path() {
     });
 }
 
-#[cfg_attr(all(not(feature="symlinks"), windows), ignore)]
 #[test]
 fn install_toolchain_linking_from_path_again() {
     setup(&|config| {
@@ -103,7 +101,6 @@ fn install_toolchain_from_path_again() {
     });
 }
 
-#[cfg_attr(all(not(feature="symlinks"), windows), ignore)]
 #[test]
 fn install_toolchain_change_from_copy_to_link() {
     setup(&|config| {
@@ -122,7 +119,6 @@ fn install_toolchain_change_from_copy_to_link() {
     });
 }
 
-#[cfg_attr(all(not(feature="symlinks"), windows), ignore)]
 #[test]
 fn install_toolchain_change_from_link_to_copy() {
     setup(&|config| {
@@ -168,7 +164,6 @@ fn install_toolchain_from_custom_wrong_extension() {
     });
 }
 
-#[cfg_attr(all(not(feature="symlinks"), windows), ignore)]
 #[test]
 fn install_override_toolchain_linking_from_path() {
     setup(&|config| {
@@ -193,7 +188,6 @@ fn install_override_toolchain_from_path() {
     });
 }
 
-#[cfg_attr(all(not(feature="symlinks"), windows), ignore)]
 #[test]
 fn install_override_toolchain_linking_from_path_again() {
     setup(&|config| {
@@ -230,7 +224,6 @@ fn install_override_toolchain_from_path_again() {
     });
 }
 
-#[cfg_attr(all(not(feature="symlinks"), windows), ignore)]
 #[test]
 fn install_override_toolchain_change_from_copy_to_link() {
     setup(&|config| {
@@ -249,7 +242,6 @@ fn install_override_toolchain_change_from_copy_to_link() {
     });
 }
 
-#[cfg_attr(all(not(feature="symlinks"), windows), ignore)]
 #[test]
 fn install_override_toolchain_change_from_link_to_copy() {
     setup(&|config| {
@@ -282,7 +274,6 @@ fn install_override_toolchain_from_custom() {
     });
 }
 
-#[cfg_attr(all(not(feature="symlinks"), windows), ignore)]
 #[test]
 fn update_toolchain_linking_from_path() {
     setup(&|config| {
@@ -309,7 +300,6 @@ fn update_toolchain_from_path() {
     });
 }
 
-#[cfg_attr(all(not(feature="symlinks"), windows), ignore)]
 #[test]
 fn update_toolchain_linking_from_path_again() {
     setup(&|config| {
@@ -348,7 +338,6 @@ fn update_toolchain_from_path_again() {
     });
 }
 
-#[cfg_attr(all(not(feature="symlinks"), windows), ignore)]
 #[test]
 fn update_toolchain_change_from_copy_to_link() {
     setup(&|config| {
@@ -368,7 +357,6 @@ fn update_toolchain_change_from_copy_to_link() {
     });
 }
 
-#[cfg_attr(all(not(feature="symlinks"), windows), ignore)]
 #[test]
 fn update_toolchain_change_from_link_to_copy() {
     setup(&|config| {
@@ -686,7 +674,6 @@ fn multi_host_smoke_test() {
     });
 }
 
-#[cfg_attr(all(not(feature="symlinks"), windows), ignore)]
 #[test]
 fn custom_toolchain_cargo_fallback_proxy() {
     setup(&|config| {
@@ -710,7 +697,6 @@ fn custom_toolchain_cargo_fallback_proxy() {
     });
 }
 
-#[cfg_attr(all(not(feature="symlinks"), windows), ignore)]
 #[test]
 fn custom_toolchain_cargo_fallback_run() {
     setup(&|config| {

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -250,7 +250,6 @@ fn list_targets_explicit() {
     });
 }
 
-#[cfg_attr(all(not(feature="symlinks"), windows), ignore)]
 #[test]
 fn link() {
     setup(&|config| {


### PR DESCRIPTION
Makes `rustup toolchain link` not require admin.