### PR TITLE
Use a consistent single blank line in install messages.

### DIFF
--- a/src/multirust-cli/self_update.rs
+++ b/src/multirust-cli/self_update.rs
@@ -105,8 +105,7 @@ modifying the HKEY_CURRENT_USER/Environment/PATH registry key."
 
 macro_rules! post_install_msg_unix {
     () => {
-r"
-Rust is installed now. Great!
+r"Rust is installed now. Great!
 
 To get started you need Cargo's bin directory in your `PATH`
 environment variable. Future shells will be configured automatically.
@@ -117,8 +116,7 @@ To configure your current shell run `source {cargo_home}/env`.
 
 macro_rules! post_install_msg_win {
     () => {
-r"
-Rust is installed now. Great!
+r"Rust is installed now. Great!
 
 To get started you need Cargo's bin directory in your `PATH`
 environment variable. Future applications will automatically have the
@@ -127,8 +125,7 @@ correct environment, but you may need to restart your current shell.
 
 macro_rules! pre_uninstall_msg {
     () => {
-r"
-Thanks for hacking in Rust!
+r"Thanks for hacking in Rust!
 
 This will uninstall all Rust toolchains and data, and remove
 `{cargo_home}/bin` from your `PATH` environment variable.
@@ -321,6 +318,7 @@ fn maybe_install_rust(toolchain_str: &str, verbose: bool) -> Result<()> {
         try!(common::show_channel_update(cfg, toolchain_str, Ok(status)));
     } else {
         info!("updating existing installation");
+        println!("");
     }
 
     Ok(())
@@ -334,6 +332,7 @@ pub fn uninstall(no_prompt: bool) -> Result<()> {
     }
 
     if !no_prompt {
+        println!("");
         let ref msg = format!(pre_uninstall_msg!(),
                               cargo_home = try!(canonical_cargo_home()));
         if !try!(confirm(msg, false)) {

--- a/tests/cli-self-update.rs
+++ b/tests/cli-self-update.rs
@@ -804,7 +804,8 @@ fn reinstall_exact() {
     setup(&|config| {
         expect_ok(config, &["rustup-setup", "-y"]);
         expect_ok_ex(config, &["rustup-setup", "-y"],
-r"",
+r"
+",
 r"info: updating existing installation
 "
                   );


### PR DESCRIPTION
Just moving around newlines to get all scenarios to have
just *one* blank line here.