### PR TITLE
issue 286: show default in 'rustup toolchain list'

### DIFF
--- a/src/multirust-cli/common.rs
+++ b/src/multirust-cli/common.rs
@@ -267,8 +267,20 @@ pub fn list_toolchains(cfg: &Cfg) -> Result<()> {
     if toolchains.is_empty() {
         println!("no installed toolchains");
     } else {
-        for toolchain in toolchains {
-            println!("{}", &toolchain);
+        if let Ok(Some(def_toolchain)) = cfg.find_default() {
+            for toolchain in toolchains {
+                let if_default = if def_toolchain.name() == &*toolchain { 
+                    " (default)" 
+                } else { 
+                    "" 
+                };
+                println!("{}{}", &toolchain, if_default);
+            }
+
+        } else {
+            for toolchain in toolchains {
+                println!("{}", &toolchain);
+            }
         }
     }
     Ok(())

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -285,6 +285,17 @@ r"");
 }
 
 #[test]
+fn list_default_toolchain() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        expect_ok_ex(config, &["rustup", "toolchain", "list"],
+for_host!(r"nightly-{0} (default)
+"),
+r"");
+    });
+}
+
+#[test]
 #[ignore(windows)] // FIXME rustup displays UNC paths
 fn show_toolchain_override() {
     setup(&|config| {


### PR DESCRIPTION
Example:

```
$ rustup toolchain list
beta-x86_64-unknown-linux-gnu
nightly-x86_64-unknown-linux-gnu
stable-x86_64-unknown-linux-gnu (default)
```

Relates to #286